### PR TITLE
Reduce ganache gas limit

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -3,7 +3,7 @@
 // - ENS address to resolve names (aragenMnemonic)
 // In order to deploy the Aragon bases a specific gas limit is needed (aragenGasLimit).
 export const testnetPort = 8545
-export const aragenGasLimit = 50e6
+export const aragenGasLimit = 10e6
 export const aragenMnemonic =
   'explain tackle mirror kit van hammer degree position ginger unfair soup bonus'
 


### PR DESCRIPTION
Apply @sohkai comment about gas limit https://github.com/aragon/buidler-aragon/pull/8#discussion_r375880995

> Perhaps we can set a more realistic number here (e.g. 10e6) to avoid someone being confused when they go to a real network.

Tested locally and the deploy succeeds but it would be necessary for other reviewers to try too.