### PR TITLE
Enforce "<name>.aragonpm.eth" ens names for development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/buidler-aragon",
-  "version": "0.0.1-beta.13",
+  "version": "0.0.1-beta.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/buidler-aragon",
-  "version": "0.0.1-beta.13",
+  "version": "0.0.1-beta.14",
   "description": "Aragon Buidler plugin",
   "main": "dist/src/index.js",
   "author": "Aragon Association <legal@aragon.org>",

--- a/src/tasks/start/start-task.ts
+++ b/src/tasks/start/start-task.ts
@@ -4,13 +4,17 @@ import { BuidlerRuntimeEnvironment } from '@nomiclabs/buidler/types'
 import { TASK_START } from '../task-names'
 import { getAppId } from './utils/id'
 import { logMain } from './utils/logger'
-import { getAppName, getAppEnsName } from './utils/arapp'
 import { startBackend } from './utils/backend/backend'
 import { startFrontend } from './utils/frontend/frontend'
 import { AragonConfig } from '~/src/types'
 import tcpPortUsed from 'tcp-port-used'
 import fsExtra from 'fs-extra'
 import path from 'path'
+import {
+  getAppName,
+  getAppEnsName,
+  isValidEnsNameForDevelopment
+} from './utils/arapp'
 
 /**
  * Main, composite, task. Calls startBackend, then startFrontend,
@@ -32,6 +36,12 @@ task(TASK_START, 'Starts Aragon app development')
     logMain(`App name: ${appName}`)
     logMain(`App ens name: ${appEnsName}`)
     logMain(`App id: ${appId}`)
+
+    if (!isValidEnsNameForDevelopment(appEnsName)) {
+      throw new BuidlerPluginError(
+        `Invalid ENS name "${appEnsName}" found in arapp.json (environments.default.appName). Only ENS names in the form "<name>.aragonpm.eth" are supported in development. Please change the value in environments.default.appName, in your project's arapp.json file. Note: Non-development environments are ignored in development and don't have this restriction.`
+      )
+    }
 
     const config: AragonConfig = bre.config.aragon as AragonConfig
     await _checkPorts(config)

--- a/src/tasks/start/utils/arapp.ts
+++ b/src/tasks/start/utils/arapp.ts
@@ -30,6 +30,27 @@ export function getAppEnsName(): string {
 }
 
 /**
+ * Validates ens names.
+ * Requires ens names to be in the form <name>.aragonpm.eth.
+ */
+export function isValidEnsNameForDevelopment(ensName: string): boolean {
+  let isValid = true
+
+  const comps = ensName.split('.')
+  const name = comps[0]
+  const domain = comps[1]
+  const ext = comps[2]
+
+  // Enforces ens names in the form <name>.aragonpm.eth.
+  isValid = comps.length !== 3 ? false : isValid
+  isValid = name.toLowerCase() !== name ? false : isValid
+  isValid = domain !== 'aragonpm' ? false : isValid
+  isValid = ext !== 'eth' ? false : isValid
+
+  return isValid
+}
+
+/**
  * Returns app name.
  * @return "voting"
  */

--- a/test/tasks/start/utils/arapp.test.ts
+++ b/test/tasks/start/utils/arapp.test.ts
@@ -4,7 +4,8 @@ import {
   getMainContractPath,
   getAppName,
   getAppEnsName,
-  readArapp
+  readArapp,
+  isValidEnsNameForDevelopment
 } from '~/src/tasks/start/utils/arapp'
 import { useDefaultEnvironment } from '~/test/test-helpers/useEnvironment'
 
@@ -34,5 +35,16 @@ describe('arapp.ts', function() {
 
   it('should retrieve the correct main contract name', function() {
     assert.equal(getMainContractName(), 'Counter')
+  })
+
+  it('should validate ens names for development', async function() {
+    assert.equal(isValidEnsNameForDevelopment('voting.aragonpm.eth'), true)
+    assert.equal(
+      isValidEnsNameForDevelopment('voting.open.aragonpm.eth'),
+      false
+    )
+    assert.equal(isValidEnsNameForDevelopment('Voting.aragonpm.eth'), false)
+    assert.equal(isValidEnsNameForDevelopment('voting.aragon.eth'), false)
+    assert.equal(isValidEnsNameForDevelopment('voting.aragonpm.btc'), false)
   })
 })


### PR DESCRIPTION
Fix https://github.com/aragon/aragon-cli/issues/1352
(sort of)

Atm, apps that define "<name>.open.aragonpm.eth" in arapp.json are failing. The failure in question results in the client not seeing the app. I believe that this is because we're not creating the "open" subdomain in the bases.

To simplify things for development, this PR makes the plugin demand names to be "<name>.aragonpm.eth". This reduces the concern of having to support any other subdomains.

@0xGabi if you believe that we should support the "open" subdomain, we may modify this PR so that the subdomain exists, but validation still checks for domains that may not exist. Without the check, the client would not see the app and thus fail silently.