### PR TITLE
Test generateArtifacts functions with a basic contract

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,10 @@ import {
   BuidlerConfig,
   BuidlerRuntimeEnvironment
 } from '@nomiclabs/buidler/types'
+import { AbiItem as AbiItemFromWeb3 } from 'web3-utils'
 import { KernelInstance } from '~/typechain'
+
+export type AbiItem = AbiItemFromWeb3
 
 export interface BuidlerAragonConfig extends BuidlerConfig {
   aragon: AragonConfig

--- a/src/utils/generateArtifacts.ts
+++ b/src/utils/generateArtifacts.ts
@@ -1,8 +1,7 @@
 import namehash from 'eth-ens-namehash'
 import web3EthAbi, { AbiCoder } from 'web3-eth-abi'
-import { AbiItem } from 'web3-utils'
 import { extractContractInfo } from './solidityExtractor'
-import { AragonAppJson, Role, AragonEnvironments } from '../types'
+import { AragonAppJson, Role, AragonEnvironments, AbiItem } from '../types'
 
 // Note: fix necessary to correct wrong 'web3-eth-abi' typings
 const { encodeFunctionSignature }: AbiCoder = web3EthAbi as any
@@ -12,14 +11,14 @@ const SOLIDITY_FILE = 'code.sol'
 interface FunctionInfo {
   sig: string // "functionName(address,unit)"
   roles: string[]
-  notice: string | null // Multiline notice text
+  notice: string // Multiline notice text
 }
 
 interface FunctionInfoWithAbi extends FunctionInfo {
   abi?: AbiItem // Abi of the function, may not be found
 }
 
-interface AragonApplicationArtifact extends AragonAppJson {
+export interface AragonApplicationArtifact extends AragonAppJson {
   flattenedCode: string
   environments: AragonEnvironments
   roles: Role[]

--- a/src/utils/solidityExtractor.ts
+++ b/src/utils/solidityExtractor.ts
@@ -4,7 +4,12 @@ import { Role } from '../types'
 interface ExtractedFunctions {
   sig: string
   roles: string[]
-  notice: string | null
+  notice: string
+}
+
+export interface ExtractedContractInfo {
+  roles: Role[]
+  functions: ExtractedFunctions[]
 }
 
 // See https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#types
@@ -89,10 +94,10 @@ const getSignature = (declaration: string): string => {
  * Get notice from function declaration
  * @param declaration multiline function declaration with comments
  */
-const getNotice = (declaration: string): string | null => {
+const getNotice = (declaration: string): string => {
   // capture from @notice to either next '* @' or end of comment '*/'
   const notices = declaration.match(/(@notice)([^]*?)(\* @|\*\/)/m)
-  if (!notices || notices.length === 0) return null
+  if (!notices || notices.length === 0) return ''
 
   return notices[0]
     .replace('*/', '')
@@ -193,7 +198,7 @@ const extractRolesFromFunctions = (
  */
 export const extractContractInfo = (
   sourceCode: string
-): { roles: Role[]; functions: ExtractedFunctions[] } => {
+): ExtractedContractInfo => {
   const functionDescriptors = extractFunctions(sourceCode)
   const roleDescriptors = extractRolesFromFunctions(functionDescriptors)
 

--- a/test/utils/contracts/BasicContract.sol
+++ b/test/utils/contracts/BasicContract.sol
@@ -1,0 +1,54 @@
+pragma solidity ^0.5.0;
+
+/*
+    NOTE: This contract is not intended to compile and is not necessarily correct.
+*/
+
+contract BasicContract {
+    uint256 value;
+
+    bytes32 public constant MODIFY_VALUE = keccak256('MODIFY_VALUE');
+    bytes32 public constant REMOVE_VALUE = keccak256('REMOVE_VALUE');
+    bytes32 public constant VERY_LONG_PERMISSION = keccak256(
+        'VERY_LONG_PERMISSION'
+    );
+
+    /**
+     * @notice Updates a value
+     * @dev Basic function with one auth
+     * @param _newValue New value
+     */
+    function modify(uint256 _newValue) public auth(MODIFY_VALUE) {
+        value = _newValue;
+    }
+
+    /**
+     * @notice Remove a value
+     * @dev Test reading multiple auths
+     */
+    function remove() public auth(MODIFY_VALUE) auth(REMOVE_VALUE) {
+        value = 0;
+    }
+
+    /**
+     * @dev Test reading multiple auths in multiple lines
+     * @dev Testing overloaded functions
+     */
+    function remove(uint256 firstInput, uint256 secondInput, uint256 thirdInput)
+        public
+        auth(MODIFY_VALUE)
+        auth(REMOVE_VALUE)
+        auth(VERY_LONG_PERMISSION)
+        returns (bool)
+    {
+        value = firstInput + secondInput + thirdInput;
+        return true;
+    }
+
+    /**
+     * @dev Test non-modifying state functions to be ignored
+     */
+    function read() internal returns (uint256) {
+        return value;
+    }
+}

--- a/test/utils/contracts/EmptyContract.sol
+++ b/test/utils/contracts/EmptyContract.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.5.0;
+
+/*
+    NOTE: This contract is not intended to compile and is not necessarily correct.
+*/
+
+contract EmptyContract {
+    uint256 public value;
+
+}

--- a/test/utils/contracts/loadContract.ts
+++ b/test/utils/contracts/loadContract.ts
@@ -1,0 +1,18 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Loads contract data as string from the directory
+ * buidler-aragon/test/utils/contracts
+ * @param contractName "EmptyContract"
+ */
+export default function loadContract(contractName: string): string {
+  return fs.readFileSync(
+    path.format({
+      dir: __dirname,
+      name: contractName,
+      ext: '.sol'
+    }),
+    'utf8'
+  )
+}

--- a/test/utils/generateApplicationArtifact.test.ts
+++ b/test/utils/generateApplicationArtifact.test.ts
@@ -1,0 +1,115 @@
+import { expect } from 'chai'
+import loadContract from './contracts/loadContract'
+import {
+  generateApplicationArtifact,
+  AragonApplicationArtifact
+} from '~/src/utils/generateArtifacts'
+import { AragonAppJson, AbiItem, Role, AragonEnvironments } from '~/src/types'
+
+describe('generateArtifacts.ts', () => {
+  describe('generateApplicationArtifact', () => {
+    it('Should parse an basic contract', () => {
+      const roles: Role[] = [
+        {
+          id: 'MODIFY_VALUE',
+          bytes:
+            '0x2594090359e7d58db7c5ce33deb3f31c1ccc8ec638404a5f3de74e519d1ee8ec',
+          name: '',
+          params: []
+        },
+        {
+          id: 'REMOVE_VALUE',
+          bytes:
+            '0x2706ec64db4fba654f10459abdcdd2830329426ecee7261f395c10cd74a8536c',
+          name: '',
+          params: []
+        },
+        {
+          id: 'VERY_LONG_PERMISSION',
+          bytes:
+            '0x3f75daf080e04c6c2535571bcc4bfaa96593a82bdcc06ed0e21eb1c589b4ba68',
+          name: '',
+          params: []
+        }
+      ]
+
+      const environments: AragonEnvironments = {}
+
+      const sourceCode = loadContract('BasicContract')
+
+      const contractEntrypointPath = 'contracts/Entrypoint.sol'
+
+      const arapp: AragonAppJson = {
+        roles,
+        environments,
+        path: contractEntrypointPath
+      }
+
+      const abiModify: AbiItem = {
+        constant: false,
+        inputs: [
+          { internalType: 'uint256', name: '_newValue', type: 'uint256' }
+        ],
+        name: 'modify',
+        outputs: [],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function'
+      }
+      const abiRemove: AbiItem = {
+        constant: false,
+        inputs: [],
+        name: 'remove',
+        outputs: [],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function'
+      }
+      const abiRemoveOverload: AbiItem = {
+        constant: false,
+        inputs: [
+          { internalType: 'uint256', name: 'firstInput', type: 'uint256' },
+          { internalType: 'uint256', name: 'secondInput', type: 'uint256' },
+          { internalType: 'uint256', name: 'thirdInput', type: 'uint256' }
+        ],
+        name: 'remove',
+        outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function'
+      }
+      const abi: AbiItem[] = [abiModify, abiRemove, abiRemoveOverload]
+
+      const expectedAragonArtifact: AragonApplicationArtifact = {
+        flattenedCode: './code.sol',
+        environments,
+        roles,
+        functions: [
+          {
+            abi: abiModify,
+            sig: 'modify(uint256)',
+            roles: ['MODIFY_VALUE'],
+            notice: 'Updates a value'
+          },
+          {
+            abi: abiRemove,
+            sig: 'remove()',
+            roles: ['MODIFY_VALUE', 'REMOVE_VALUE'],
+            notice: 'Remove a value'
+          },
+          {
+            abi: abiRemoveOverload,
+            sig: 'remove(uint256,uint256,uint256)',
+            roles: ['MODIFY_VALUE', 'REMOVE_VALUE', 'VERY_LONG_PERMISSION'],
+            notice: ''
+          }
+        ],
+        abi,
+        path: contractEntrypointPath
+      }
+
+      const aragonArtifact = generateApplicationArtifact(arapp, abi, sourceCode)
+      expect(aragonArtifact).to.deep.equal(expectedAragonArtifact)
+    })
+  })
+})

--- a/test/utils/solidityExtractor.test.ts
+++ b/test/utils/solidityExtractor.test.ts
@@ -1,0 +1,72 @@
+import { expect } from 'chai'
+import loadContract from './contracts/loadContract'
+import {
+  extractContractInfo,
+  ExtractedContractInfo
+} from '~/src/utils/solidityExtractor'
+
+describe('solidityExtractor.ts', () => {
+  describe('extractContractInfo', () => {
+    it('Should parse an empty contract', () => {
+      const expectedContractInfo: ExtractedContractInfo = {
+        roles: [],
+        functions: []
+      }
+
+      const sourceCode = loadContract('EmptyContract')
+
+      const contractInfo = extractContractInfo(sourceCode)
+      expect(contractInfo).to.deep.equal(expectedContractInfo)
+    })
+
+    it('Should parse an basic contract', () => {
+      const expectedContractInfo: ExtractedContractInfo = {
+        roles: [
+          {
+            id: 'MODIFY_VALUE',
+            bytes:
+              '0x2594090359e7d58db7c5ce33deb3f31c1ccc8ec638404a5f3de74e519d1ee8ec',
+            name: '',
+            params: []
+          },
+          {
+            id: 'REMOVE_VALUE',
+            bytes:
+              '0x2706ec64db4fba654f10459abdcdd2830329426ecee7261f395c10cd74a8536c',
+            name: '',
+            params: []
+          },
+          {
+            id: 'VERY_LONG_PERMISSION',
+            bytes:
+              '0x3f75daf080e04c6c2535571bcc4bfaa96593a82bdcc06ed0e21eb1c589b4ba68',
+            name: '',
+            params: []
+          }
+        ],
+        functions: [
+          {
+            sig: 'modify(uint256)',
+            roles: ['MODIFY_VALUE'],
+            notice: 'Updates a value'
+          },
+          {
+            sig: 'remove()',
+            roles: ['MODIFY_VALUE', 'REMOVE_VALUE'],
+            notice: 'Remove a value'
+          },
+          {
+            sig: 'remove(uint256,uint256,uint256)',
+            roles: ['MODIFY_VALUE', 'REMOVE_VALUE', 'VERY_LONG_PERMISSION'],
+            notice: ''
+          }
+        ]
+      }
+
+      const sourceCode = loadContract('BasicContract')
+
+      const contractInfo = extractContractInfo(sourceCode)
+      expect(contractInfo).to.deep.equal(expectedContractInfo)
+    })
+  })
+})


### PR DESCRIPTION
Test the functions added in https://github.com/aragon/buidler-aragon/pull/7 against an EmptyContract and a BasicContract with different auth consuming functions.

Completes item 1 of "What's next" of https://github.com/aragon/buidler-aragon/pull/7