### PR TITLE
Bootstrap publish task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/buidler-aragon",
-  "version": "0.0.1-beta.14",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1151,7 +1151,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -1404,8 +1403,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -1997,6 +1995,14 @@
         "browserslist": "^3.2.6",
         "invariant": "^2.2.2",
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "babel-register": {
@@ -2085,8 +2091,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -2142,7 +2147,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
       "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -2150,8 +2154,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -2253,6 +2256,11 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -2309,11 +2317,34 @@
         }
       }
     },
+    "borc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.1.tgz",
+      "integrity": "sha512-vPLLC2/gS0QN4O3cnPh+8jLshkMMD4qIfs+B1TPGPh30WrtcfItaO6j4k9alsqu/hIgKi8dVdmMvTcbq4tIF7A==",
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.8",
+        "iso-url": "~0.4.4",
+        "json-text-sequence": "~0.1.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2433,7 +2464,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-      "dev": true,
       "requires": {
         "base-x": "^3.0.2"
       }
@@ -2453,7 +2483,6 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
       "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -2663,6 +2692,17 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
+    "cids": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.3.tgz",
+      "integrity": "sha512-V0xa0oFIH1GGsGE4vaTsAgiTkrZw3wUVOTAVN/oZU8ptW6oaz4cOdFbqRv+tbienIZq5bG2ok0CRKfUurUtFnA==",
+      "requires": {
+        "class-is": "^1.1.0",
+        "multibase": "~0.6.0",
+        "multicodec": "^1.0.0",
+        "multihashes": "~0.4.15"
+      }
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -2672,6 +2712,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -2790,7 +2835,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2829,8 +2873,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "config-chain": {
       "version": "1.1.12",
@@ -3288,8 +3331,12 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "depd": {
       "version": "1.1.2",
@@ -3534,6 +3581,11 @@
       "requires": {
         "ansi-colors": "^3.2.1"
       }
+    },
+    "err-code": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
+      "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
     },
     "errno": {
       "version": "0.1.7",
@@ -4723,8 +4775,7 @@
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
       "version": "3.1.2",
@@ -5000,6 +5051,11 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fast-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
+      "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -5244,8 +5300,7 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -19298,6 +19353,11 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+    },
     "get-proxy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
@@ -19582,6 +19642,11 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "hi-base32": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.0.tgz",
+      "integrity": "sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -19699,8 +19764,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -19909,6 +19973,11 @@
         "fp-ts": "^1.0.0"
       }
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
@@ -19919,6 +19988,127 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
       "dev": true
+    },
+    "ipfs-block": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.1.tgz",
+      "integrity": "sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==",
+      "requires": {
+        "cids": "~0.7.0",
+        "class-is": "^1.1.0"
+      }
+    },
+    "ipfs-http-client": {
+      "version": "42.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-42.0.0.tgz",
+      "integrity": "sha512-ysA1splRSil7DDJuw5qK7YVwf0SygpQDRf9vrMRApcvaL8bWwqa9rJVCkMx/S8D9LAZ5VDSaJP2fmIdpvAIK9g==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "bignumber.js": "^9.0.0",
+        "bs58": "^4.0.1",
+        "buffer": "^5.4.2",
+        "cids": "~0.7.1",
+        "debug": "^4.1.0",
+        "form-data": "^3.0.0",
+        "ipfs-block": "~0.8.1",
+        "ipfs-utils": "^0.7.1",
+        "ipld-dag-cbor": "^0.15.1",
+        "ipld-dag-pb": "^0.18.2",
+        "ipld-raw": "^4.0.1",
+        "it-tar": "^1.1.1",
+        "it-to-stream": "^0.1.1",
+        "iterable-ndjson": "^1.1.0",
+        "ky": "^0.15.0",
+        "ky-universal": "^0.3.0",
+        "merge-options": "^2.0.0",
+        "multiaddr": "^7.2.1",
+        "multiaddr-to-uri": "^5.1.0",
+        "multibase": "~0.6.0",
+        "multicodec": "^1.0.0",
+        "multihashes": "~0.4.14",
+        "parse-duration": "^0.1.1",
+        "stream-to-it": "^0.2.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "ipfs-utils": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.7.1.tgz",
+      "integrity": "sha512-oAZrlv3z92951hA28ZSsvPgoe70/SDRi48CaCXp+EhJbvvdBYkxR2FJBRI1T1sV0Lvu7F0xpo6Nv5lGMRNy8KA==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "err-code": "^2.0.0",
+        "fs-extra": "^8.1.0",
+        "is-electron": "^2.2.0",
+        "it-glob": "0.0.7",
+        "ky": "^0.15.0",
+        "ky-universal": "^0.3.0",
+        "stream-to-it": "^0.2.0"
+      }
+    },
+    "ipld-dag-cbor": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.1.tgz",
+      "integrity": "sha512-V0ZSpC0DvnYSjC4RgyezHMZMx8g/keSi5jikElLbzCXPdRRoOemJoMBUedmIWwQaY+6f2UDbHr2qf9ZmVeL4Mw==",
+      "requires": {
+        "borc": "^2.1.0",
+        "cids": "~0.7.0",
+        "is-circular": "^1.0.2",
+        "multicodec": "^1.0.0",
+        "multihashing-async": "~0.8.0"
+      }
+    },
+    "ipld-dag-pb": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.2.tgz",
+      "integrity": "sha512-CG+PIPoOmHr0AnQjijRoY633VzozWRn45zLoJ+qjiSS7r7Dy5JrScWpq4t3DOsCID7blV3ULRfRLcuvvs2SlSA==",
+      "requires": {
+        "cids": "~0.7.1",
+        "class-is": "^1.1.0",
+        "multicodec": "^1.0.0",
+        "multihashing-async": "~0.8.0",
+        "protons": "^1.0.1",
+        "stable": "~0.1.8"
+      }
+    },
+    "ipld-raw": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-4.0.1.tgz",
+      "integrity": "sha512-WjIdtZ06jJEar8zh+BHB84tE6ZdbS/XNa7+XCArOYfmeJ/c01T9VQpeMwdJQYn5c3s5UvvCu7y4VIi3vk2g1bA==",
+      "requires": {
+        "cids": "~0.7.0",
+        "multicodec": "^1.0.0",
+        "multihashing-async": "~0.8.0"
+      }
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -19969,6 +20159,11 @@
       "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
       "dev": true
     },
+    "is-circular": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
+      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
+    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -20014,6 +20209,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
       "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+    },
+    "is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -20076,6 +20276,21 @@
       "requires": {
         "global-dirs": "^0.1.1",
         "is-path-inside": "^2.1.0"
+      }
+    },
+    "is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "requires": {
+        "ip-regex": "^4.0.0"
+      },
+      "dependencies": {
+        "ip-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
+          "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
+        }
       }
     },
     "is-natural-number": {
@@ -20200,6 +20415,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
+    "iso-url": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.6.tgz",
+      "integrity": "sha512-YQO7+aIe6l1aSJUKOx+Vrv08DlhZeLFIVfehG2L29KLSEb9RszqPXilxJRVpp57px36BddKR5ZsebacO5qG0tg=="
+    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -20229,6 +20449,152 @@
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
+      }
+    },
+    "it-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.0.tgz",
+      "integrity": "sha512-mLhiCB3tW4NTYTg7bMlyYX2c782KsAacthHMR3y5kjJn9JhNFb02NcH70KZuNrSXFSTq8k6m8MiYaQWRjrDxAA==",
+      "requires": {
+        "bl": "^4.0.0"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.0.tgz",
+          "integrity": "sha512-QwQvAZZA1Bw1FWnhNj2X5lu+sPxxB2ITH3mqEqYyahN6JZR13ONjk+XiTnBaGEzMPUrAgOkaD68pBH1rvPRPsw==",
+          "requires": {
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "it-glob": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.7.tgz",
+      "integrity": "sha512-XfbziJs4fi0MfdEGTLkZXeqo2EorF2baFXxFn1E2dGbgYMhFTZlZ2Yn/mx5CkpuLWVJvO1DwtTOVW2mzRyVK8w==",
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "it-reader": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-2.1.0.tgz",
+      "integrity": "sha512-hSysqWTO9Tlwc5EGjVf8JYZzw0D2FsxD/g+eNNWrez9zODxWt6QlN6JAMmycK72Mv4jHEKEXoyzUN4FYGmJaZw==",
+      "requires": {
+        "bl": "^4.0.0"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.0.tgz",
+          "integrity": "sha512-QwQvAZZA1Bw1FWnhNj2X5lu+sPxxB2ITH3mqEqYyahN6JZR13ONjk+XiTnBaGEzMPUrAgOkaD68pBH1rvPRPsw==",
+          "requires": {
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "it-tar": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/it-tar/-/it-tar-1.2.1.tgz",
+      "integrity": "sha512-PX6p2VQdLdKCrPIVitjgRcdap5dQmSNF/eWtvq/5XVedeRUDNZa0di2MlAzX9F9iYbbf4BZOrMEgNnfEEIJ2/w==",
+      "requires": {
+        "bl": "^4.0.0",
+        "buffer": "^5.4.3",
+        "fs-constants": "^1.0.0",
+        "it-concat": "^1.0.0",
+        "it-reader": "^2.0.0",
+        "p-defer": "^3.0.0"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.0.tgz",
+          "integrity": "sha512-QwQvAZZA1Bw1FWnhNj2X5lu+sPxxB2ITH3mqEqYyahN6JZR13ONjk+XiTnBaGEzMPUrAgOkaD68pBH1rvPRPsw==",
+          "requires": {
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "it-to-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-0.1.1.tgz",
+      "integrity": "sha512-QQx/58JBvT189imr6fD234F8aVf8EdyQHJR0MxXAOShEWK1NWyahPYIQt/tQG7PId0ZG/6/3tUiVCfw2cq+e1w==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "iterable-ndjson": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
+      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+      "requires": {
+        "string_decoder": "^1.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "js-sha3": {
@@ -20332,6 +20698,14 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "requires": {
+        "delimit-stream": "0.1.0"
+      }
+    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -20415,6 +20789,27 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "ky": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.15.0.tgz",
+      "integrity": "sha512-6IlJRPFHq4ZKRRa9lyh6YqHqlmddAkfyXI9CYvZpLQtg7fQvwncPHyHrmtXAHKCqHOilINPMT88eW6FTA3HwkA=="
+    },
+    "ky-universal": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.3.0.tgz",
+      "integrity": "sha512-CM4Bgb2zZZpsprcjI6DNYTaH3oGHXL2u7BU4DK+lfCuC4snkt9/WRpMYeKbBbXscvKkeqBwzzjFX2WwmKY5K/A==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
       }
     },
     "lcid": {
@@ -20635,6 +21030,14 @@
         "prr": "~1.0.1",
         "semver": "~5.4.1",
         "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        }
       }
     },
     "levn": {
@@ -21460,6 +21863,21 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
+    "merge-options": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-2.0.0.tgz",
+      "integrity": "sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==",
+      "requires": {
+        "is-plain-obj": "^2.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+        }
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -21683,7 +22101,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -21838,6 +22255,88 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "multiaddr": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.3.0.tgz",
+      "integrity": "sha512-HlV0oMy5dq+vV1t5hFL8T559j7cdgODnCQEXqDATL7oZyN6hWKJOZ4XE45LkdVJc7/A4cCLZmVg7RCBjj0wfyQ==",
+      "requires": {
+        "bs58": "^4.0.1",
+        "cids": "~0.7.1",
+        "class-is": "^1.1.0",
+        "hi-base32": "~0.5.0",
+        "ip": "^1.1.5",
+        "is-ip": "^3.1.0",
+        "varint": "^5.0.0"
+      }
+    },
+    "multiaddr-to-uri": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.1.0.tgz",
+      "integrity": "sha512-rIlMLkw3yk3RJmf2hxYYzeqPXz4Vx7C4M/hg7BVWhmksDW0rDVNMEyoVb0H1A+sh3deHOh5EAFK87XcW+mFimA==",
+      "requires": {
+        "multiaddr": "^7.2.1"
+      }
+    },
+    "multibase": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
+      "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
+      "requires": {
+        "base-x": "3.0.4"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        }
+      }
+    },
+    "multicodec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.0.tgz",
+      "integrity": "sha512-CBiLdYcMnVnkN/2kL4AaUH3betYXQGKV5CCmN2CfgHUt5xROtsj91w780ltX6Wy7frgc6en8md3h2UQl6jDXAg==",
+      "requires": {
+        "varint": "^5.0.0"
+      }
+    },
+    "multihashes": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.15.tgz",
+      "integrity": "sha512-G/Smj1GWqw1RQP3dRuRRPe3oyLqvPqUaEDIaoi7JF7Loxl4WAWvhJNk84oyDEodSucv0MmSW/ZT0RKUrsIFD3g==",
+      "requires": {
+        "bs58": "^4.0.1",
+        "varint": "^5.0.0"
+      }
+    },
+    "multihashing-async": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.0.tgz",
+      "integrity": "sha512-t0iDSl1kkI65vaKmv9/bBM9/E/ogywB18+A9hI7QzcQjolue1tcaNWKdoFuniF6QQtNOJFplO4nQtLfQeK3lLw==",
+      "requires": {
+        "blakejs": "^1.1.0",
+        "buffer": "^5.4.3",
+        "err-code": "^2.0.0",
+        "js-sha3": "~0.8.0",
+        "multihashes": "~0.4.15",
+        "murmurhash3js-revisited": "^3.0.0"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        }
+      }
+    },
+    "murmurhash3js-revisited": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
+      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -21924,6 +22423,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -22200,6 +22707,11 @@
       "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
       "dev": true
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
     "p-event": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
@@ -22207,6 +22719,15 @@
       "dev": true,
       "requires": {
         "p-timeout": "^2.0.1"
+      }
+    },
+    "p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "requires": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
       }
     },
     "p-finally": {
@@ -22282,6 +22803,11 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "parse-duration": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.1.2.tgz",
+      "integrity": "sha512-0qfMZyjOUFBeEIvJ5EayfXJqaEXxQ+Oj2b7tWJM3hvEXvXsYCk05EDVI23oYnEw2NaFYUWdABEVPBvBMh8L/pA=="
     },
     "parse-headers": {
       "version": "2.0.3",
@@ -22493,6 +23019,22 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
+    },
+    "protocol-buffers-schema": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
+      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
+    },
+    "protons": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/protons/-/protons-1.1.0.tgz",
+      "integrity": "sha512-rxf3et88VGRJkXIcDK1nemQM9OpnKsRVuZW+vkJLRmytA6530hQ+k/r2DpclNJCYF+xUl2MXsvRsK+MJgcbfEg==",
+      "requires": {
+        "protocol-buffers-schema": "^3.3.1",
+        "safe-buffer": "^5.1.1",
+        "signed-varint": "^2.0.1",
+        "varint": "^5.0.0"
+      }
     },
     "proxy-addr": {
       "version": "2.0.5",
@@ -23045,10 +23587,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.2.tgz",
+      "integrity": "sha512-BJs9T/H8sEVHbeigqzIEo57Iu/3DG6c4QoqTfbQB3BPA4zgzAomh/Fk9E7QtjWQ8mx2dgA9YCfSF4y9k9bHNpQ=="
     },
     "send": {
       "version": "0.17.1",
@@ -23227,6 +23768,14 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "signed-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
+      "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
+      "requires": {
+        "varint": "~5.0.0"
+      }
     },
     "simple-concat": {
       "version": "1.0.0",
@@ -23425,6 +23974,12 @@
           "requires": {
             "graceful-fs": "^4.1.6"
           }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -23554,6 +24109,11 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -23584,6 +24144,15 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "requires": {
         "duplexer": "~0.1.1"
+      }
+    },
+    "stream-to-it": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.0.tgz",
+      "integrity": "sha512-bK/N8LPMc4FgNxXwIRBbJDWg2GYUfnVGH++hTM5SjCHzyPPWYp2ml+wnqaO86+y0SywZDxPAZSNAPP3Wii/QzQ==",
+      "requires": {
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0"
       }
     },
     "strict-uri-encode": {
@@ -24762,6 +25331,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "varint": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
     "execa": "^4.0.0",
     "fs-extra": "^8.1.0",
     "ganache-core": "^2.10.1",
+    "ipfs-http-client": "^42.0.0",
     "live-server": "^1.2.1",
     "open": "^7.0.0",
+    "semver": "^7.1.2",
     "tcp-port-used": "^1.0.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export default function(): void {
 
   // Task definitions.
   require(path.join(__dirname, '/tasks/start/start-task'))
+  require(path.join(__dirname, '/tasks/publish'))
 
   // Environment extensions.
   // No extensions atm.

--- a/src/tasks/publish/index.ts
+++ b/src/tasks/publish/index.ts
@@ -1,0 +1,93 @@
+import { task, types } from '@nomiclabs/buidler/config'
+import { BuidlerRuntimeEnvironment } from '@nomiclabs/buidler/types'
+import { BuidlerPluginError } from '@nomiclabs/buidler/plugins'
+import { TASK_PUBLISH } from '../task-names'
+import { AragonConfig } from '~/src/types'
+import { execaPipe } from '../start/utils/execa'
+import uploadDirToIpfs from './utils/uploadDirToIpfs'
+import apmNewVersion from './utils/apmNewVersion'
+import { generateAppArtifacts } from '../start/utils/frontend/app'
+import { getMainContractName, getAppEnsName } from '../start/utils/arapp'
+
+const validBumps = ['major', 'minor', 'patch']
+
+/**
+ * Main, composite, task. Calls startBackend, then startFrontend,
+ * and then returns an unresolving promise to keep the task open.
+ */
+task(TASK_PUBLISH, 'Publish a new app version')
+  .addPositionalParam(
+    'bump',
+    'Type of bump (major, minor or patch) or version number',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'developerAddress',
+    'Owner of the APM repo. Must be provided in the initial release',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'ipfsProvider',
+    'Provider URL to connect to an ipfs daemon API server',
+    'http://localhost:5001',
+    types.string
+  )
+  .setAction(async (taskArgs, bre: BuidlerRuntimeEnvironment) => {
+    const bump: string = taskArgs.bump
+    const developerAddress: string = taskArgs.developerAddress
+    const ipfsProvider: string = taskArgs.ipfsProvider
+    const config: AragonConfig = bre.config.aragon as AragonConfig
+    const contractName = getMainContractName()
+    const appEnsName = getAppEnsName()
+    const appSrcPath = config.appSrcPath as string
+    const appBuildOutputPath = config.appBuildOutputPath as string
+    const ipfsIgnore = ['subfolder/to/ignore/**']
+    // Hardcoded until a better way to deal with dynamic ENS address is found
+    const registryAddress = '0x5f6F7E8cc7346a11ca2dEf8f827b7a0b612c56a1'
+
+    if (!validBumps.includes(bump))
+      throw new BuidlerPluginError(
+        `Invalid bump ${bump}, must be: ${validBumps.join(', ')}`
+      )
+
+    // Compile contracts
+    await bre.run('compile')
+
+    // Deploy contract
+    const MainContract = bre.artifacts.require(contractName)
+    const mainContract = await MainContract.new()
+    const contractAddress = mainContract.address
+    /* eslint-disable-next-line no-console */
+    console.log(`Implementation contract deployed: ${contractAddress}`)
+
+    // Prepare release directory
+    // npm run build must create: index.html, src.js, script.js
+    await execaPipe('npm', ['run', 'build'], { cwd: appSrcPath })
+    await generateAppArtifacts(appBuildOutputPath, bre.artifacts)
+
+    // Upload release directory to IPFS
+    const contentHash = await uploadDirToIpfs(
+      appBuildOutputPath,
+      ipfsIgnore,
+      ipfsProvider
+    )
+    /* eslint-disable-next-line no-console */
+    console.log(`Release directory uploaded to IPFS: ${contentHash}`)
+
+    // Publish new app to aragonPM
+    const { versionId, version } = await apmNewVersion(
+      {
+        appEnsName,
+        bump,
+        contentHash,
+        contractAddress,
+        developerAddress,
+        registryAddress
+      },
+      bre
+    )
+    /* eslint-disable-next-line no-console */
+    console.log(`Successfully released version ${versionId}: ${version}`)
+  })

--- a/src/tasks/publish/utils/apmNewVersion.ts
+++ b/src/tasks/publish/utils/apmNewVersion.ts
@@ -1,0 +1,142 @@
+import { BuidlerPluginError } from '@nomiclabs/buidler/plugins'
+import { BuidlerRuntimeEnvironment } from '@nomiclabs/buidler/types'
+import { Ens } from './resolveEns'
+import {
+  RepoContract,
+  RepoInstance,
+  APMRegistryContract,
+  APMRegistryInstance
+} from '~/typechain'
+import { getLog } from '../../start/utils/backend/logs'
+import semver from 'semver'
+
+interface ApmRepoVersion {
+  semanticVersion: [string, string, string]
+  contractAddress: string
+  contentURI: string
+}
+
+export default async function apmNewVersion(
+  {
+    bump,
+    contractAddress,
+    contentHash,
+    appEnsName,
+    developerAddress,
+    registryAddress
+  }: {
+    bump: string
+    contractAddress: string
+    contentHash: string
+    appEnsName: string
+    developerAddress?: string
+    registryAddress: string
+  },
+  bre: BuidlerRuntimeEnvironment
+): Promise<{ versionId: number; version: string }> {
+  const contentURI = `0x${Buffer.from(`ipfs:${contentHash}`).toString('hex')}`
+
+  const ens = Ens({
+    registryAddress,
+    provider: bre.web3.currentProvider
+  })
+
+  const repoAddress = await ens.lookup(appEnsName)
+
+  if (repoAddress) {
+    // If repo address exists, release a new version
+    const Repo: RepoContract = artifacts.require('Repo')
+    const repo: RepoInstance = await Repo.at(repoAddress)
+    const currentRelease: ApmRepoVersion = (await repo.getLatest()) as any
+    const currentVersion = arrayToVersion(currentRelease.semanticVersion)
+    const nextVersion = bumpSemver(currentVersion, bump)
+    if (currentRelease.contractAddress !== contractAddress && bump !== 'major')
+      throw new BuidlerPluginError(
+        `Contract address has changed, bump must be major`
+      )
+
+    const txResponse = await repo.newVersion(
+      versionToArray(nextVersion),
+      contractAddress,
+      contentURI
+    )
+    const versionId: string = getLog(txResponse, 'NewVersion', 'versionId')
+
+    return { versionId: parseInt(versionId), version: nextVersion }
+  } else {
+    // If repo does not exists, create and release
+    const initialVersion = bumpSemver('0.0.0', bump)
+    if (!developerAddress)
+      throw new BuidlerPluginError(
+        `a developerAddress must be provided to release the initial version of a repo`
+      )
+
+    const apmRegistryName = getAppNameRegistry(appEnsName)
+    const apmRegistryAddress = await ens.lookup(apmRegistryName)
+    if (!apmRegistryAddress)
+      throw new BuidlerPluginError(
+        `APM registry ${apmRegistryName} does not exist. Is your app name correct? '${appEnsName}'`
+      )
+    const APMRegistry: APMRegistryContract = artifacts.require('APMRegistry')
+    const apmRegistry: APMRegistryInstance = await APMRegistry.at(
+      apmRegistryAddress
+    )
+
+    await apmRegistry.newRepoWithVersion(
+      appEnsName,
+      developerAddress,
+      versionToArray(initialVersion),
+      contractAddress,
+      contentURI
+    )
+    return { versionId: 0, version: initialVersion }
+  }
+}
+
+/**
+ * Returns the APM registry of an app name
+ * @param ensName "finance.custompm.eth"
+ * @return "custompm.eth"
+ */
+function getAppNameRegistry(ensName: string): string {
+  return ensName
+    .split('.')
+    .slice(1)
+    .join('.')
+}
+
+/**
+ * Wrapper since semver.inc happily returns null if bump is not valid
+ * @param version "0.2.0"
+ * @param bump "major"
+ * @return "1.0.0"
+ */
+function bumpSemver(version: string, bump: string): string {
+  const nextVersion = semver.inc(version, bump)
+  if (!nextVersion) throw Error(`Invalid bump: ${bump}`)
+  return nextVersion
+}
+
+/**
+ * Util to convert a semver in string format to APM repo array form
+ * @param version "1.2.3"
+ * @return ["1", "2", "3"]
+ */
+function versionToArray(version: string): [string, string, string] {
+  const major = semver.major(version)
+  const minor = semver.minor(version)
+  const patch = semver.patch(version)
+  return [String(major), String(minor), String(patch)]
+}
+
+/**
+ * Util to convert a semver in APM repo array form to string format
+ * @param versionArray ["1", "2", "3"]
+ * @return "1.2.3"
+ */
+function arrayToVersion(versionArray: [string, string, string]): string {
+  const version = versionArray.slice(0, 3).join('.')
+  if (!semver.valid(version))
+    throw Error(`Invalid semver array: ${versionArray}`)
+  return version
+}

--- a/src/tasks/publish/utils/resolveEns.ts
+++ b/src/tasks/publish/utils/resolveEns.ts
@@ -1,0 +1,51 @@
+import ENS from 'ethjs-ens'
+
+/**
+ * Initialize and Ens instance to resolve names or nodes
+ * @param options
+ */
+export function Ens(options: {
+  registryAddress: string
+  provider: any
+}): { lookup: (nameOrNode: string) => Promise<string> } {
+  // Stupid hack for ethjs-ens
+  if (!options.provider.sendAsync) {
+    options.provider.sendAsync = options.provider.send
+  }
+
+  const ens = new ENS(options)
+  return {
+    lookup: async (nameOrNode: string): Promise<string> => {
+      try {
+        return await ens.lookup(nameOrNode)
+      } catch (e) {
+        if (e.message.includes('name not defined')) return ''
+        else throw e
+      }
+    }
+  }
+}
+
+/**
+ * Shortcut to resolveEns without the initialized object
+ * @param nameOrNode
+ * @param options
+ */
+export async function resolveEns(
+  nameOrNode: string,
+  options: { registryAddress: string; provider: any }
+): Promise<string> {
+  const ens = Ens(options)
+  return await ens.lookup(nameOrNode)
+}
+
+/**
+ * Compute the ENS namehash of a name
+ * @param name "aragonpm.eth"
+ * @return "0x9065c3e7f7b7ef1ef4e53d2d0b8e0cef02874ab020c1ece79d5f0d3d0111c0ba"
+ */
+export function namehash(name: string): string {
+  // Mock initialization to access the internal `namehash` function
+  const ens = new ENS({ provider: {}, registryAddress: '0x' })
+  return ens.namehash(name)
+}

--- a/src/tasks/publish/utils/uploadDirToIpfs.ts
+++ b/src/tasks/publish/utils/uploadDirToIpfs.ts
@@ -1,0 +1,50 @@
+/* eslint-disable-next-line @typescript-eslint/no-var-requires */
+import IPFS from 'ipfs-http-client'
+
+const { globSource } = IPFS
+
+/**
+ * Uploads a directory to IPFS
+ * @param dirPath './dist'
+ * @param ignore ['subfolder/to/ignore/**']
+ * @param ipfsProvider 'http://localhost:5001'
+ * @return Root directory hash = 'Qm...'
+ */
+export default async function uploadDirToIpfs(
+  dirPath: string,
+  ignoreGlobs: string[],
+  ipfsProvider: string
+): Promise<string> {
+  const ipfs = new IPFS(ipfsProvider)
+
+  const showProgress = true
+  const progress = (prog: number): void => {
+    // Do something with progress
+    // console.log(`Uploading... ${prog}`)
+  }
+
+  const globOptions = {
+    recursive: true,
+    ignore: ignoreGlobs
+  }
+
+  const addOptions = {
+    pin: true,
+    ...(showProgress ? { progress } : {})
+  }
+
+  const files: { path: string; hash: string }[] = []
+  for await (const file of ipfs.add(
+    globSource(dirPath, globOptions),
+    addOptions
+  )) {
+    files.push({
+      path: file.path,
+      hash: file.cid.toString()
+    })
+  }
+
+  const rootDir = files.pop()
+  if (!rootDir) throw Error(`No root entry found: ${JSON.stringify(files)}`)
+  return rootDir.hash
+}

--- a/src/tasks/task-names.ts
+++ b/src/tasks/task-names.ts
@@ -1,5 +1,6 @@
 // Aragon plugin tasks.
 export const TASK_START = 'start'
+export const TASK_PUBLISH = 'publish'
 
 // Buidler built-in tasks.
 export const TASK_COMPILE = 'compile'


### PR DESCRIPTION
Developed a working publish task. 

To try it out you must start an IPFS node and a testnet (if applicable). See reasoning below:

*Terminal 1*
```
ipfs daemon
```
*Terminal 2*
```
aragon devchain
```
*Terminal 3*
```
cd buidler-aragon/test/projects/counter
npx buidler publish major
```

## Discussion

*Note:* This task will require further discussion on various contentious topics such as:
- How to handle the UX of uploading and pinning IPFS. Spinning a local IPFS node may give a false impression to the user that the app is available while it will not at the moment the laptop is shutdown. I would favor offering Infura or an Aragon open IPFS node to starting users and never starting a local node. Then, for more experienced users give instructions on how to link with providers (Piñata) or construct their own IPFS persistent services.
- For the moment we should not start a ganache instance for the publish task. To deploy an app locally users should use the start task.
- Executing transactions directly from a builder plugin run doesn't seem secure to me. I would prefer to output a prefilled link or transaction data that can be reviewed, verified and executed latter in a more transparent manner. I wonder, do Aragon devs have the private keys with access to repos such as `finance.aragonpm.eth` locally in a laptop for the `aragon-cli` to have access to? Or what is the current procedure for sensitive apps such as this?