### PR TITLE
Better detect when the npm script serve is ready

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20307,6 +20307,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "fs-extra": "^8.1.0",
     "ganache-core": "^2.10.1",
     "live-server": "^1.2.1",
+    "node-fetch": "^2.6.0",
     "open": "^7.0.0",
     "source-map-support": "^0.5.16",
     "tcp-port-used": "^1.0.1"


### PR DESCRIPTION
Fix #6

Instead of parsing the logs and looking for a specific string it queries the server at intervals until it returns an `index.html`. It waits for a maximum of 60 seconds (adjustable) after which it resolves regardless of whether the server is ready or not. If the detection fails this timeout will save the day and if the wait was actually longer than the maximum wait the user can always refresh the window.

The package `node-fetch` is used to do the request since it's already used by key dependencies of the project

```
buidler-aragon$ npm ls node-fetch
@aragon/buidler-aragon@0.0.5 aragon/buidler-aragon
├─┬ @nomiclabs/buidler@1.1.2
│ └── node-fetch@2.6.0 
└─┬ ganache-core@2.10.1
  └─┬ web3-provider-engine@14.2.1
    ├─┬ cross-fetch@2.2.3
    │ └── node-fetch@2.1.2 
    └─┬ eth-json-rpc-infura@3.2.1
      └─┬ eth-json-rpc-middleware@1.6.0
        └─┬ fetch-ponyfill@4.1.0
          └── node-fetch@1.7.3 
```
This technique of querying the server could be expanded to verify that the user has configured the app well to serve all the mandatory files (index.html, script, etc)