### PR TITLE
Use buidlerevm JSON RPC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8304,6 +8304,24 @@
             "keccak": "^2.0.0",
             "rlp": "^2.2.3",
             "secp256k1": "^3.0.1"
+          },
+          "dependencies": {
+            "keccak": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+              "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+              "requires": {
+                "bindings": "^1.5.0",
+                "inherits": "^2.0.4",
+                "nan": "^2.14.0",
+                "safe-buffer": "^5.2.0"
+              }
+            },
+            "nan": {
+              "version": "2.14.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+            }
           }
         },
         "ethereumjs-vm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/buidler-aragon",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -83,15 +83,16 @@
       }
     },
     "@nomiclabs/buidler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.1.2.tgz",
-      "integrity": "sha512-yDtTzp8x3enUo3CsKIneUqikd9fb7N/8IsUWVQywDNzVi9Bc+1Xp3lYTfG+qdusZVOYuf48GGZxWG4iohzIgZg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.2.0.tgz",
+      "integrity": "sha512-4jnJgvcG15tG5HHDuxR0l8eCqx0Fdt3KnYjamtp63Ht3vAoEoU2zNOFtDghElMkApZxvqzDzjfhOdPi70yCnKw==",
       "dev": true,
       "requires": {
         "@nomiclabs/ethereumjs-vm": "^4.1.1",
         "@types/bn.js": "^4.11.5",
         "@types/lru-cache": "^5.1.0",
         "abort-controller": "^3.0.0",
+        "ansi-escapes": "^4.3.0",
         "bip32": "^2.0.3",
         "bip39": "^3.0.2",
         "chalk": "^2.4.2",
@@ -118,13 +119,16 @@
         "mocha": "^5.2.0",
         "node-fetch": "^2.6.0",
         "qs": "^6.7.0",
+        "raw-body": "^2.4.1",
         "semver": "^6.3.0",
+        "slash": "^3.0.0",
         "solc": "0.5.15",
         "solidity-parser-antlr": "^0.4.2",
         "source-map-support": "^0.5.13",
         "ts-essentials": "^2.0.7",
         "tsort": "0.0.1",
-        "uuid": "^3.3.2"
+        "uuid": "^3.3.2",
+        "ws": "^7.2.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -194,6 +198,18 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
+        "raw-body": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+          "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+          "dev": true,
+          "requires": {
+            "bytes": "3.1.0",
+            "http-errors": "1.7.3",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -202,13 +218,19 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        },
+        "ws": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+          "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==",
+          "dev": true
         }
       }
     },
     "@nomiclabs/buidler-truffle5": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler-truffle5/-/buidler-truffle5-1.1.2.tgz",
-      "integrity": "sha512-+SlvAZzqaodXD1XkDO9NzY5XYbd4NFFWw9ogTp04DQLic0jJVM/xBNHJBNUPyq7y+Eh2AQmGNjjlnbnfF+P4ow==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler-truffle5/-/buidler-truffle5-1.2.0.tgz",
+      "integrity": "sha512-1/ZbSt2o+cafe+MUsThrJjUrWCbgiDj4G3Ds+1/PNeuHuB/hmTVNkz3BFT7kje+QYgfNr21tOlxPaBdoe91cZA==",
       "dev": true,
       "requires": {
         "@nomiclabs/truffle-contract": "^4.1.2",
@@ -232,10 +254,13 @@
       }
     },
     "@nomiclabs/buidler-web3": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler-web3/-/buidler-web3-1.1.2.tgz",
-      "integrity": "sha512-u4wl3T5Q2CKIKAzk8+dV/IUl2yetZL6eQGa56AMBOx3Sh/xq1WLpaT4GaWhRIKfrAjRrSF1jBDgPYBmZx3zLrA==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler-web3/-/buidler-web3-1.2.0.tgz",
+      "integrity": "sha512-RS5OzaR2LYeb59lXFmIZrIewGEYGWfXCLq46uVkdotCx7uIEKgz1KgV0VhylfIGnUA1w1kklZhD2PcOeT9A7JA==",
+      "dev": true,
+      "requires": {
+        "@types/bignumber.js": "^5.0.0"
+      }
     },
     "@nomiclabs/ethereumjs-vm": {
       "version": "4.1.1",
@@ -468,6 +493,15 @@
             "web3-utils": "1.2.1"
           }
         }
+      }
+    },
+    "@types/bignumber.js": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
+      "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "*"
       }
     },
     "@types/bn.js": {
@@ -991,9 +1025,9 @@
       }
     },
     "base-x": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
-      "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -8270,24 +8304,6 @@
             "keccak": "^2.0.0",
             "rlp": "^2.2.3",
             "secp256k1": "^3.0.1"
-          },
-          "dependencies": {
-            "keccak": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-              "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-              "requires": {
-                "bindings": "^1.5.0",
-                "inherits": "^2.0.4",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.2.0"
-              }
-            },
-            "nan": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
-            }
           }
         },
         "ethereumjs-vm": {
@@ -21230,6 +21246,12 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -23183,9 +23205,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.15.tgz",
-          "integrity": "sha512-daFGV9GSs6USfPgxceDA8nlSe48XrVCJfDeYm7eokxq/ye7iuOH87hKXgMtEAVLFapkczbZsx868PMDT1Y0a6A==",
+          "version": "10.17.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
+          "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==",
           "dev": true
         },
         "elliptic": {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
   },
   "devDependencies": {
     "@aragon/abis": "^1.1.0",
-    "@nomiclabs/buidler": "^1.0.2",
-    "@nomiclabs/buidler-truffle5": "^1.0.2",
-    "@nomiclabs/buidler-web3": "^1.0.2",
+    "@nomiclabs/buidler": "^1.2.0",
+    "@nomiclabs/buidler-truffle5": "^1.2.0",
+    "@nomiclabs/buidler-web3": "^1.2.0",
     "@types/chai": "^4.2.5",
     "@types/mocha": "^5.2.7",
     "@types/node": "12.7.5",
@@ -66,9 +66,9 @@
     "web3": "^1.2.4"
   },
   "peerDependencies": {
-    "@nomiclabs/buidler": "^1.0.2",
-    "@nomiclabs/buidler-truffle5": "^1.0.2",
-    "@nomiclabs/buidler-web3": "^1.0.2",
+    "@nomiclabs/buidler": "^1.2.0",
+    "@nomiclabs/buidler-truffle5": "^1.2.0",
+    "@nomiclabs/buidler-web3": "^1.2.0",
     "bignumber.js": "^9.0.0",
     "web3": "^1.2.4"
   }

--- a/src/tasks/start/start-backend.ts
+++ b/src/tasks/start/start-backend.ts
@@ -44,20 +44,25 @@ export async function startBackend(
 
   await _compileDisablingOutput(bre, silent)
 
+  // Dev: Single boolean to do A/B testing
+  const useNodeTask = true
+
   /**
    * Until BuidlerEVM JSON RPC is ready, a ganache server will be started
    * on the appropiate conditions.
    */
-  if (bre.network.name === 'buidlerevm') {
-    // Run the "node" task with starts a JSON-RPC attached to the buidlerevm network
-    // NOTE: The "node" task can NOT be awaited since it now waits until the server closes
-    // TODO: add a configuration to the task that awaits only until listen
-    bre.run(TASK_NODE, { port: testnetPort })
-    await _waitForPortUsed(testnetPort)
-  } else if (bre.network.name === 'localhost') {
-    const networkId = await startGanache(bre)
-    if (networkId !== 0) {
-      logBack(`Started a ganache testnet instance with id ${networkId}.`)
+  if (bre.network.name === 'localhost') {
+    if (useNodeTask) {
+      // Run the "node" task with starts a JSON-RPC attached to the buidlerevm network
+      // NOTE: The "node" task can NOT be awaited since it now waits until the server closes
+      // TODO: add a configuration to the task that awaits only until listen
+      bre.run(TASK_NODE, { port: testnetPort })
+      await _waitForPortUsed(testnetPort)
+    } else {
+      const networkId = await startGanache(bre)
+      if (networkId !== 0) {
+        logBack(`Started a ganache testnet instance with id ${networkId}.`)
+      }
     }
   } else {
     throw new BuidlerPluginError(

--- a/test/projects/counter/buidler.config.ts
+++ b/test/projects/counter/buidler.config.ts
@@ -9,6 +9,7 @@ usePlugin('@nomiclabs/buidler-web3')
 import { loadPluginFile } from '@nomiclabs/buidler/plugins-testing'
 loadPluginFile(__dirname + '/../../../src/index')
 import { BuidlerAragonConfig } from '../../../src/types'
+import { BuidlerNetworkConfig } from '@nomiclabs/buidler/types'
 
 const config: BuidlerAragonConfig = {
   defaultNetwork: 'localhost',
@@ -24,11 +25,12 @@ const config: BuidlerAragonConfig = {
       url: 'http://localhost:8546'
     },
     buidlerevm: {
+      loggingEnabled: false,
       accounts: aragenAccounts.map(account => ({
         privateKey: account.privateKey,
         balance: "0x21e19e0c9bab2400000"
       }))
-    }
+    } as BuidlerNetworkConfig
   },
   solc: {
     version: '0.4.24'

--- a/test/projects/counter/buidler.config.ts
+++ b/test/projects/counter/buidler.config.ts
@@ -11,7 +11,7 @@ loadPluginFile(__dirname + '/../../../src/index')
 import { BuidlerAragonConfig } from '../../../src/types'
 
 const config: BuidlerAragonConfig = {
-  defaultNetwork: 'buidlerevm',
+  defaultNetwork: 'localhost',
   networks: {
     localhost: {
       url: 'http://localhost:8545',

--- a/test/projects/counter/buidler.config.ts
+++ b/test/projects/counter/buidler.config.ts
@@ -1,4 +1,5 @@
 import { usePlugin } from '@nomiclabs/buidler/config'
+import { aragenAccounts } from '../../../src/params'
 
 usePlugin('@nomiclabs/buidler-truffle5')
 usePlugin('@nomiclabs/buidler-web3')
@@ -10,7 +11,7 @@ loadPluginFile(__dirname + '/../../../src/index')
 import { BuidlerAragonConfig } from '../../../src/types'
 
 const config: BuidlerAragonConfig = {
-  defaultNetwork: 'localhost',
+  defaultNetwork: 'buidlerevm',
   networks: {
     localhost: {
       url: 'http://localhost:8545',
@@ -21,6 +22,12 @@ const config: BuidlerAragonConfig = {
     },
     someothernetwork: {
       url: 'http://localhost:8546'
+    },
+    buidlerevm: {
+      accounts: aragenAccounts.map(account => ({
+        privateKey: account.privateKey,
+        balance: "0x21e19e0c9bab2400000"
+      }))
     }
   },
   solc: {

--- a/test/projects/counter/package-lock.json
+++ b/test/projects/counter/package-lock.json
@@ -10,14 +10,15 @@
       "integrity": "sha512-SbdF3JkU+57N19GEENtUvs/nsjOKdK+YlG35o3qdhK8AMZO+AWZU3wb5FyezR4hHHDZfijxhzYTXGIf0zNAdPQ=="
     },
     "@nomiclabs/buidler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.1.2.tgz",
-      "integrity": "sha512-yDtTzp8x3enUo3CsKIneUqikd9fb7N/8IsUWVQywDNzVi9Bc+1Xp3lYTfG+qdusZVOYuf48GGZxWG4iohzIgZg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.2.0.tgz",
+      "integrity": "sha512-4jnJgvcG15tG5HHDuxR0l8eCqx0Fdt3KnYjamtp63Ht3vAoEoU2zNOFtDghElMkApZxvqzDzjfhOdPi70yCnKw==",
       "requires": {
         "@nomiclabs/ethereumjs-vm": "^4.1.1",
         "@types/bn.js": "^4.11.5",
         "@types/lru-cache": "^5.1.0",
         "abort-controller": "^3.0.0",
+        "ansi-escapes": "^4.3.0",
         "bip32": "^2.0.3",
         "bip39": "^3.0.2",
         "chalk": "^2.4.2",
@@ -44,19 +45,52 @@
         "mocha": "^5.2.0",
         "node-fetch": "^2.6.0",
         "qs": "^6.7.0",
+        "raw-body": "^2.4.1",
         "semver": "^6.3.0",
+        "slash": "^3.0.0",
         "solc": "0.5.15",
         "solidity-parser-antlr": "^0.4.2",
         "source-map-support": "^0.5.13",
         "ts-essentials": "^2.0.7",
         "tsort": "0.0.1",
-        "uuid": "^3.3.2"
+        "uuid": "^3.3.2",
+        "ws": "^7.2.1"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "raw-body": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+          "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+          "requires": {
+            "bytes": "3.1.0",
+            "http-errors": "1.7.3",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        },
+        "ws": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+          "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
+        }
       }
     },
     "@nomiclabs/buidler-truffle5": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler-truffle5/-/buidler-truffle5-1.1.2.tgz",
-      "integrity": "sha512-+SlvAZzqaodXD1XkDO9NzY5XYbd4NFFWw9ogTp04DQLic0jJVM/xBNHJBNUPyq7y+Eh2AQmGNjjlnbnfF+P4ow==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler-truffle5/-/buidler-truffle5-1.2.0.tgz",
+      "integrity": "sha512-1/ZbSt2o+cafe+MUsThrJjUrWCbgiDj4G3Ds+1/PNeuHuB/hmTVNkz3BFT7kje+QYgfNr21tOlxPaBdoe91cZA==",
       "requires": {
         "@nomiclabs/truffle-contract": "^4.1.2",
         "@types/chai": "^4.2.0",
@@ -66,9 +100,12 @@
       }
     },
     "@nomiclabs/buidler-web3": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler-web3/-/buidler-web3-1.1.2.tgz",
-      "integrity": "sha512-u4wl3T5Q2CKIKAzk8+dV/IUl2yetZL6eQGa56AMBOx3Sh/xq1WLpaT4GaWhRIKfrAjRrSF1jBDgPYBmZx3zLrA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/buidler-web3/-/buidler-web3-1.2.0.tgz",
+      "integrity": "sha512-RS5OzaR2LYeb59lXFmIZrIewGEYGWfXCLq46uVkdotCx7uIEKgz1KgV0VhylfIGnUA1w1kklZhD2PcOeT9A7JA==",
+      "requires": {
+        "@types/bignumber.js": "^5.0.0"
+      }
     },
     "@nomiclabs/ethereumjs-vm": {
       "version": "4.1.1",
@@ -249,6 +286,14 @@
         }
       }
     },
+    "@types/bignumber.js": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
+      "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
+      "requires": {
+        "bignumber.js": "*"
+      }
+    },
     "@types/bn.js": {
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
@@ -395,6 +440,14 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
       "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
     },
+    "ansi-escapes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+      "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -511,9 +564,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base-x": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
-      "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -3955,6 +4008,11 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+    },
     "solc": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.15.tgz",
@@ -4417,6 +4475,11 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -5198,9 +5261,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.15.tgz",
-          "integrity": "sha512-daFGV9GSs6USfPgxceDA8nlSe48XrVCJfDeYm7eokxq/ye7iuOH87hKXgMtEAVLFapkczbZsx868PMDT1Y0a6A=="
+          "version": "10.17.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
+          "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
         },
         "elliptic": {
           "version": "6.3.3",

--- a/test/projects/counter/package.json
+++ b/test/projects/counter/package.json
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@aragon/abis": "^1.1.0",
-    "@nomiclabs/buidler": "^1.0.2",
-    "@nomiclabs/buidler-truffle5": "^1.0.2",
-    "@nomiclabs/buidler-web3": "^1.0.2",
+    "@nomiclabs/buidler": "^1.2.0",
+    "@nomiclabs/buidler-truffle5": "^1.2.0",
+    "@nomiclabs/buidler-web3": "^1.2.0",
     "@types/chai": "^4.2.5",
     "@types/mocha": "^5.2.7",
     "@types/node": "12.7.5",


### PR DESCRIPTION
Successfully starts the buidlerevm JSON RPC server. Builds on https://github.com/aragon/buidler-aragon/pull/25

### Test

```
cd aragon/buidler-aragon/test/projects/counter
```
```
npx buidler start
```

### Limitations

> In current buidler version `1.2.0` 

The task `node` creates a new buidler EVM instance, different from the one consumed by the internal instances of clients (web3, artifacts). To fix this, the network used must be "localhost" which connects to the buidler EVM instance created by the `node` task.

Now the client **do can** find the DAO but **can not** find the app proxy contract
