### PR TITLE
Append defaults and arapp to buidler config

### DIFF
--- a/src/config/aragon.ts
+++ b/src/config/aragon.ts
@@ -1,5 +1,6 @@
 import { ConfigExtender } from '@nomiclabs/buidler/types'
 import { AragonConfig } from '../types'
+import { readArappIfExists } from '../utils/arappUtils'
 
 export const defaultAragonConfig: AragonConfig = {
   appServePort: 8001,
@@ -9,8 +10,42 @@ export const defaultAragonConfig: AragonConfig = {
 }
 
 export const configExtender: ConfigExtender = (finalConfig, userConfig) => {
+  // Apply defaults
   finalConfig.aragon = {
     ...defaultAragonConfig,
-    ...userConfig.aragon
+    ...(userConfig.aragon || {})
+  }
+
+  // Fetch network specific app names from arapp.json
+  const arapp = readArappIfExists()
+  if (arapp && typeof arapp.environments === 'object') {
+    const appNames: { [network: string]: string } = {}
+    for (const [network, env] of Object.entries(arapp.environments)) {
+      if (env.appName) appNames[network] = env.appName
+    }
+
+    const userAppName = (userConfig.aragon || {}).appName
+    const appNamesArr = Object.values(appNames)
+    const thereAreNames = appNamesArr.length > 0
+    const allNamesAreEqual = appNamesArr.every(name => name === appNamesArr[0])
+    if (thereAreNames) {
+      if (allNamesAreEqual) {
+        // Only add it if it's not defined in the buidler.config
+        if (!userAppName) {
+          finalConfig.aragon.appName = appNamesArr[0]
+        }
+      } else {
+        finalConfig.aragon.appName = {
+          ...appNames,
+          // Merge buidler config app names if any
+          // If there's one single appName add it as "default"
+          ...(typeof userAppName === 'object'
+            ? userAppName
+            : typeof userAppName === 'string'
+            ? { default: userAppName }
+            : {})
+        }
+      }
+    }
   }
 }

--- a/src/config/aragon.ts
+++ b/src/config/aragon.ts
@@ -1,0 +1,16 @@
+import { ConfigExtender } from '@nomiclabs/buidler/types'
+import { AragonConfig } from '../types'
+
+export const defaultAragonConfig: AragonConfig = {
+  appServePort: 8001,
+  clientServePort: 3000,
+  appSrcPath: 'app/',
+  appBuildOutputPath: 'dist/'
+}
+
+export const configExtender: ConfigExtender = (finalConfig, userConfig) => {
+  finalConfig.aragon = {
+    ...defaultAragonConfig,
+    ...userConfig.aragon
+  }
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,10 @@
+import { ConfigExtender } from '@nomiclabs/buidler/types'
+import { configExtender as configExtenderMnemonic } from './mnemonic'
+import { configExtender as configExtenderNetworks } from './networks'
+import { configExtender as configExtenderAragon } from './aragon'
+
+export const configExtender: ConfigExtender = (finalConfig, userConfig) => {
+  configExtenderNetworks(finalConfig, userConfig)
+  configExtenderMnemonic(finalConfig, userConfig)
+  configExtenderAragon(finalConfig, userConfig)
+}

--- a/src/config/mnemonic.ts
+++ b/src/config/mnemonic.ts
@@ -1,0 +1,65 @@
+import { homedir } from 'os'
+import path from 'path'
+import fs from 'fs'
+import { ConfigExtender, HttpNetworkConfig } from '@nomiclabs/buidler/types'
+
+// Standard Aragon test paths
+const aragonConfig = '.aragon'
+const genericName = 'mnemonic.json'
+const byNetworkName = (network: string): string => `${network}_key.json`
+const defaultMnemonic =
+  'explain tackle mirror kit van hammer degree position ginger unfair soup bonus'
+
+interface GenericMnemonic {
+  mnemonic: string
+}
+interface ByNetworkMnemonic {
+  rpc?: string
+  keys?: string[] // privateKeys = [ "3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580" ];
+}
+
+export const configExtender: ConfigExtender = (finalConfig, userConfig) => {
+  const genericMnemonic = readAragonConfig<GenericMnemonic>(genericName)
+
+  // Add mnemonics from .aragon config only to selected networks
+  for (const networkName of ['mainnet', 'ropsten', 'rinkeby', 'kovan']) {
+    // Apply defaults. Note networks may not exists in finalConfig
+    const finalNetwork = {
+      ...((userConfig.networks || {})[networkName] || {}),
+      // Add finalConfig in case a previous configExtender has modified it
+      ...((finalConfig.networks || {})[networkName] || {})
+    } as HttpNetworkConfig
+
+    // Apply account data from the config folder
+    const byNetworkMnemonic = readAragonConfig<ByNetworkMnemonic>(
+      byNetworkName(networkName)
+    )
+    if (byNetworkMnemonic) {
+      const { rpc, keys } = byNetworkMnemonic
+      if (!finalNetwork.url && rpc) finalNetwork.url = rpc
+      if (!finalNetwork.accounts && keys) finalNetwork.accounts = keys
+    }
+    // Generic mnemonic
+    if (genericMnemonic && !finalNetwork.accounts) {
+      finalNetwork.accounts = genericMnemonic
+    }
+    // Fallback mnemonic
+    if (!finalNetwork.accounts) {
+      finalNetwork.accounts = {
+        mnemonic: defaultMnemonic
+      }
+    }
+  }
+}
+
+/**
+ * Utility to read JSON files from aragonConfig dirs
+ * Returns undefined if the file does not exist
+ * @param filename 'mnemonic.json'
+ */
+function readAragonConfig<T>(filename: string): T | undefined {
+  const filepath = path.join(homedir(), aragonConfig, filename)
+  return fs.existsSync(filepath)
+    ? JSON.parse(fs.readFileSync(filepath, 'utf8'))
+    : undefined
+}

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -1,0 +1,88 @@
+import { ConfigExtender, HttpNetworkConfig } from '@nomiclabs/buidler/types'
+import { Networks } from '@nomiclabs/buidler/types'
+import { readArappIfExists } from '../utils/arappUtils'
+
+const aragonRpc = (network: string): string =>
+  `https://${network}.eth.aragon.network`
+const localRpc = 'http://localhost:8545'
+const coverageRpc = 'http://localhost:8555'
+
+const defaultNetworks: Networks = {
+  rpc: {
+    chainId: 15,
+    url: localRpc,
+    gas: 6.9e6,
+    gasPrice: 15000000001
+  },
+  devnet: {
+    chainId: 16,
+    url: localRpc,
+    gas: 6.9e6,
+    gasPrice: 15000000001
+  },
+  mainnet: {
+    chainId: 1,
+    url: aragonRpc('mainnet'),
+    gas: 7.9e6,
+    gasPrice: 3000000001
+  },
+  ropsten: {
+    chainId: 3,
+    url: aragonRpc('ropsten'),
+    gas: 4.712e6
+  },
+  rinkeby: {
+    chainId: 4,
+    url: aragonRpc('rinkeby'),
+    gas: 6.9e6,
+    gasPrice: 15000000001
+  },
+  kovan: {
+    chainId: 42,
+    url: aragonRpc('kovan'),
+    gas: 6.9e6
+  },
+  coverage: {
+    url: coverageRpc,
+    gas: 0xffffffffff,
+    gasPrice: 0x01
+  },
+  development: {
+    url: localRpc,
+    gas: 6.9e6,
+    gasPrice: 15000000001
+  }
+}
+
+export const configExtender: ConfigExtender = (finalConfig, userConfig) => {
+  // Apply defaults. Note networks may not exists in finalConfig
+  for (const [networkName, network] of Object.entries(defaultNetworks)) {
+    finalConfig.networks[networkName] = {
+      ...network,
+      ...((userConfig.networks || {})[networkName] || {}),
+      // Add finalConfig in case a previous configExtender has modified it
+      ...((finalConfig.networks || {})[networkName] || {})
+    } as HttpNetworkConfig
+  }
+
+  // Apply networks from arapp.json
+  const arapp = readArappIfExists()
+  if (arapp && typeof arapp.environments === 'object') {
+    for (const [networkName, network] of Object.entries(arapp.environments)) {
+      if (network.network && finalConfig.networks[network.network]) {
+        const finalNetwork = finalConfig.networks[
+          network.network
+        ] as HttpNetworkConfig
+
+        // Append registry address
+        if (network.registry) {
+          finalNetwork.ensAddress = network.registry
+        }
+
+        // Create an alias of the declared network to an existing network
+        if (network.network !== networkName)
+          finalConfig.networks[networkName] = finalNetwork
+      }
+    }
+  }
+}

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -6,6 +6,7 @@ const aragonRpc = (network: string): string =>
   `https://${network}.eth.aragon.network`
 const localRpc = 'http://localhost:8545'
 const coverageRpc = 'http://localhost:8555'
+const frameRpc = 'ws://localhost:1248'
 
 const defaultNetworks: Networks = {
   rpc: {
@@ -51,6 +52,9 @@ const defaultNetworks: Networks = {
     url: localRpc,
     gas: 6.9e6,
     gasPrice: 15000000001
+  },
+  frame: {
+    url: frameRpc
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { extendConfig, usePlugin } from '@nomiclabs/buidler/config'
 import path from 'path'
-import { defaultAragonConfig } from './params'
+import { configExtender } from './config'
+
 // TODO: Don't use any type below, try to use something like these...
 // import { ResolvedBuidlerConfig, BuidlerConfig } from '@nomiclabs/buidler/types'
 
@@ -19,10 +20,5 @@ export default function(): void {
   // No extensions atm.
 
   // Default configuration values.
-  extendConfig((finalConfig: any, userConfig: any) => {
-    finalConfig.aragon = {
-      ...defaultAragonConfig,
-      ...userConfig.aragon
-    }
-  })
+  extendConfig(configExtender)
 }

--- a/src/params.ts
+++ b/src/params.ts
@@ -1,5 +1,3 @@
-import { AragonConfig } from './types'
-
 // The Aragon web client expects certain parameters to work locally:
 // - Local testnet node to connect to (testnetPort)
 // - ENS address to resolve names (aragenMnemonic)
@@ -66,11 +64,4 @@ export const defaultLocalAragonBases = {
   ensAddress: '0x5f6F7E8cc7346a11ca2dEf8f827b7a0b612c56a1',
   daoFactoryAddress: '0x8EEaea23686c319133a7cC110b840d1591d9AeE0',
   apmAddress: '0xA53dE0b8e08b798f975D57f48384C177D410d170'
-}
-
-export const defaultAragonConfig: AragonConfig = {
-  appServePort: 8001,
-  clientServePort: 3000,
-  appSrcPath: 'app/',
-  appBuildOutputPath: 'dist/'
 }

--- a/src/type-extensions.d.ts
+++ b/src/type-extensions.d.ts
@@ -4,4 +4,8 @@ declare module '@nomiclabs/buidler/types' {
   interface BuidlerConfig {
     aragon?: AragonConfig
   }
+
+  interface HttpNetworkConfig {
+    ensAddress?: string
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,15 @@ export interface AragonConfig {
   clientServePort?: number
   appSrcPath?: string
   appBuildOutputPath?: string
+  /**
+   * If the appName is different per network use object form
+   * ```ts
+   * appName: {
+   *   rinkeby: "myapp.open.aragonpm.eth"
+   * }
+   * ```
+   */
+  appName?: string | { [network: string]: string }
   hooks?: AragonConfigHooks
 }
 

--- a/src/utils/arappUtils.ts
+++ b/src/utils/arappUtils.ts
@@ -16,6 +16,14 @@ export function readArapp(): AragonAppJson {
 }
 
 /**
+ * Reads and parses an arapp.json file only if exists
+ * otherwise returns undefined
+ */
+export function readArappIfExists(): AragonAppJson | undefined {
+  if (fs.existsSync(arappPath)) return readArapp()
+}
+
+/**
  * Returns app ens name.
  * @return "voting.open.aragonpm.eth"
  */

--- a/test/src/index.test.ts
+++ b/test/src/index.test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai'
 import { useEnvironment } from '~/test/test-helpers/useEnvironment'
 import { AragonConfig, AragonConfigHooks } from '~/src/types'
-import { defaultAragonConfig } from '~/src/params'
+import { defaultAragonConfig } from '~/src/config/aragon'
 
 describe('index.ts', () => {
   describe('default config', async function() {

--- a/test/src/index.test.ts
+++ b/test/src/index.test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai'
 import { useEnvironment } from '~/test/test-helpers/useEnvironment'
 import { AragonConfig, AragonConfigHooks } from '~/src/types'
 import { defaultAragonConfig } from '~/src/config/aragon'
+import { pick } from 'lodash'
 
 describe('index.ts', () => {
   describe('default config', async function() {
@@ -17,7 +18,11 @@ describe('index.ts', () => {
       })
 
       it('resulting config contains default values', function() {
-        assert.deepEqual(config, defaultConfig, 'config is different')
+        assert.deepEqual(
+          pick(config, Object.keys(defaultConfig)),
+          defaultConfig,
+          'config is different'
+        )
       })
     })
 


### PR DESCRIPTION
Move the current [truffle-config-v5](https://github.com/aragon/contract-helpers/blob/master/packages/truffle-config-v5/truffle-config.js) [truffle-config-v4](https://github.com/aragon/contract-helpers/blob/master/packages/truffle-config-v4/truffle-config.js) semantics, networks, and mnemonic paths to buidler natively. 

Also, read arapp.json add append its environments as networks accessible by buidler.

### Details

The network and mnemonics are injected with the extendConfig buidler pattern. It looks like the old's CLI middleware but fully typed :+1: . To make thing manageable, networks, menmonic and aragon configs are split in different composable extendConfig functions that can be run in sequence in `config/index`

### Test

The start command can only be used in localhost but other networks can be tried out via the console
```sh
# setup
npm i && npm run dev
cd buidler-aragon/test/projects/counter
```
```sh
# Mainnet
npx buidler console --network mainnet
> await web3.eth.getBlockNumber()
9698461

# Rinkeby
npx buidler console --network rinkeby
> await web3.eth.getBlockNumber()
6161224
```