### PR TITLE
Add extra publish test cases

### DIFF
--- a/src/tasks/publish/index.ts
+++ b/src/tasks/publish/index.ts
@@ -101,12 +101,7 @@ async function publishTask(
 
   // TODO: Warn the user their metadata files (e.g. appName) are not correct.
 
-  const appName =
-    typeof aragonConfig.appName === 'string'
-      ? aragonConfig.appName
-      : typeof aragonConfig.appName === 'object'
-      ? aragonConfig.appName[selectedNetwork]
-      : undefined
+  const appName = _parseAppName(aragonConfig.appName, selectedNetwork)
   if (!appName)
     throw new BuidlerPluginError(`appName must be defined in buidler.config`)
   const contractName = getMainContractName()
@@ -248,4 +243,36 @@ async function _getChainId(bre: BuidlerRuntimeEnvironment): Promise<number> {
   const provider = new ethers.providers.Web3Provider(bre.web3.currentProvider)
   const net = await provider.getNetwork()
   return net.chainId
+}
+
+/**
+ * Utility to parse appName from the aragon config
+ * @param appNameOrObj
+ * @param network
+ */
+function _parseAppName(
+  appNameOrObj: string | { [network: string]: string } | undefined,
+  network: string
+): string {
+  switch (typeof appNameOrObj) {
+    case 'string':
+      if (!appNameOrObj)
+        throw new BuidlerPluginError(
+          `appName must not be empty in buidler.config`
+        )
+      return appNameOrObj
+
+    case 'object':
+      if (!appNameOrObj[network])
+        throw new BuidlerPluginError(
+          `No appName defined for network '${network}' in buidler.config`
+        )
+      else return appNameOrObj[network]
+
+    default:
+      throw new BuidlerPluginError(
+        `appName is buidler.config is of type ${typeof appNameOrObj}
+It must a string or an object { [network]: appName}`
+      )
+  }
 }

--- a/src/tasks/publish/index.ts
+++ b/src/tasks/publish/index.ts
@@ -101,7 +101,7 @@ async function publishTask(
 
   // TODO: Warn the user their metadata files (e.g. appName) are not correct.
 
-  const appName = _parseAppName(aragonConfig.appName, selectedNetwork)
+  const appName = _parseAppNameFromConfig(aragonConfig.appName, selectedNetwork)
   if (!appName)
     throw new BuidlerPluginError(`appName must be defined in buidler.config`)
   const contractName = getMainContractName()
@@ -250,7 +250,7 @@ async function _getChainId(bre: BuidlerRuntimeEnvironment): Promise<number> {
  * @param appNameOrObj
  * @param network
  */
-function _parseAppName(
+function _parseAppNameFromConfig(
   appNameOrObj: string | { [network: string]: string } | undefined,
   network: string
 ): string {

--- a/src/utils/accounts.ts
+++ b/src/utils/accounts.ts
@@ -1,0 +1,12 @@
+import { BuidlerRuntimeEnvironment } from '@nomiclabs/buidler/types'
+
+/**
+ * Returns the root or default account from a runtime environment
+ * @param bre
+ */
+export async function getRootAccount(
+  bre: BuidlerRuntimeEnvironment
+): Promise<string> {
+  const accounts = await bre.web3.eth.getAccounts()
+  return accounts[0]
+}

--- a/src/utils/apm/publishVersion.ts
+++ b/src/utils/apm/publishVersion.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers'
 import semver from 'semver'
 import { ApmVersion, AragonJsIntent, PublishVersionTxData } from './types'
 import { toApmVersionArray } from './utils'
-import { appStorageAbi, apmRegistryAbi } from './abis'
+import { appStorageAbi, apmRegistryAbi, repoAbi } from './abis'
 
 /**
  * Return the kernel address of an aragon app contract
@@ -112,9 +112,19 @@ export function encodePublishVersionTxData({
   methodName,
   params
 }: {
-  methodName: string
+  methodName: 'newVersion' | 'newRepoWithVersion'
   params: any[]
 }): string {
-  const apmRegistry = new ethers.utils.Interface(apmRegistryAbi)
-  return apmRegistry.functions[methodName].encode(params)
+  switch (methodName) {
+    case 'newRepoWithVersion':
+      const apmRegistry = new ethers.utils.Interface(apmRegistryAbi)
+      return apmRegistry.functions.newRepoWithVersion.encode(params)
+
+    case 'newVersion':
+      const apmRepo = new ethers.utils.Interface(repoAbi)
+      return apmRepo.functions.newVersion.encode(params)
+
+    default:
+      throw Error(`Unsupported publish version method name: ${methodName}`)
+  }
 }

--- a/src/utils/apm/utils.ts
+++ b/src/utils/apm/utils.ts
@@ -61,10 +61,12 @@ export function contentUriToFetchUrl(
   contentUri: string,
   options?: { ipfsGateway?: string }
 ): string {
+  if (!contentUri) throw Error(`contentUri is empty`)
   const [protocol, location] = contentUri.split(/[/:](.+)/)
   switch (protocol) {
     case 'http':
     case 'https':
+      if (!location) throw Error(`contentUri location not set: ${contentUri}`)
       return location.includes('://') ? location : contentUri
     case 'ipfs':
       if (!options || !options.ipfsGateway)

--- a/src/utils/appName.ts
+++ b/src/utils/appName.ts
@@ -34,6 +34,7 @@ export function getFullAppName(
   appName: string,
   registry = DEFAULT_APM_REGISTRY
 ): string {
+  if (!appName) throw Error(`appName is not defined`)
   // Already full ENS domain
   if (appName.includes('.')) return appName
   // Concat with registry

--- a/test/projects/test-app/buidler.config.js
+++ b/test/projects/test-app/buidler.config.js
@@ -27,6 +27,10 @@ module.exports = {
     clientServePort: 3042, // Intentionally not using default value (3000).
     appSrcPath: 'app/',
     appBuildOutputPath: 'dist/',
+    appName: {
+      localhost: "test.aragonpm.eth",
+      mainnet: "finance.aragonpm.eth"
+    },
     hooks: require("./aragon-hooks")
   }
 }

--- a/test/src/tasks/publish-task.test.ts
+++ b/test/src/tasks/publish-task.test.ts
@@ -23,6 +23,7 @@ import {
   BuidlerRuntimeEnvironment,
   HttpNetworkConfig
 } from '@nomiclabs/buidler/types'
+import { getRootAccount } from '~/src/utils/accounts'
 
 interface RepoState {
   repoAddress: string
@@ -117,16 +118,6 @@ describe('Publish task', function() {
       { path: 'contracts/TestContract.sol' },
       'artifact.json does not include expected data'
     )
-  }
-
-  /**
-   * Test util to fetch the root account
-   * @param bre
-   */
-  async function getRootAccount(
-    bre: BuidlerRuntimeEnvironment
-  ): Promise<string> {
-    return (await bre.web3.eth.getAccounts())[0]
   }
 
   /**

--- a/test/src/tasks/publish-task.test.ts
+++ b/test/src/tasks/publish-task.test.ts
@@ -5,82 +5,108 @@ import { AragonConfig } from '~/src/types'
 import { startGanache } from '~/src/tasks/start/backend/start-ganache'
 import deployBases from '~/src/tasks/start/backend/bases/deploy-bases'
 import {
-  PublishVersionTxData,
   resolveRepoContentUri,
-  isAddress
+  isAddress,
+  PublishVersionTxData,
+  encodePublishVersionTxData
 } from '~/src/utils/apm'
 import { infuraIpfsApiUrl, infuraIpfsGateway } from '~/test/testParams'
 import { defaultLocalAragonBases } from '~/src/params'
+import { ethers } from 'ethers'
+import { getRepoVersion } from '~/src/utils/apm'
+import semver, { ReleaseType } from 'semver'
+import {
+  parseNewRepoWithVersionTxData,
+  parseNewVersionTxData
+} from '~/test/test-helpers/publishVersionTxParsers'
+import {
+  BuidlerRuntimeEnvironment,
+  HttpNetworkConfig
+} from '@nomiclabs/buidler/types'
 
-const testAppDir = 'test-app'
-const testAppContract = 'TestContract'
-const testNetwork = 'localhost'
+interface RepoState {
+  repoAddress: string
+  version: string
+  contractAddress: string
+}
 
-describe(`Run publish task - ${testAppDir}`, function() {
-  const ipfsApiUrl = infuraIpfsApiUrl
-  const ipfsGateway = infuraIpfsGateway
-  const managerAddress = '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B'
-  const bump = 'major'
+const ipfsApiUrl = infuraIpfsApiUrl
+const ipfsGateway = infuraIpfsGateway
+const appName = 'test.aragonpm.eth'
 
-  let config: AragonConfig
-  let closeGanache: (() => void) | undefined
-  let txData: PublishVersionTxData
+describe('Publish task', function() {
+  const testAppDir = 'test-app'
 
-  useEnvironment(testAppDir, testNetwork)
-
-  before('Retrieve config', async function() {
-    config = this.env.config.aragon as AragonConfig
-  })
-
-  before('Run a local testnet with bases', async function() {
-    const ganache = await startGanache(this.env)
-    closeGanache = ganache.close
-    const aragonBases = await deployBases(this.env)
-  })
-
-  before('Run publish task', async function() {
-    txData = await this.env.run(TASK_PUBLISH, {
-      bump,
-      managerAddress,
-      ipfsApiUrl
-    })
-  })
-
-  it('Static release parameters should be correct', () => {
-    const { to, methodName, params } = txData
-    // Compare with an object to see all of them at once
-    assert.deepEqual(
-      {
-        to,
-        methodName,
-        shortName: params[0],
-        managerAddress: params[1],
-        versionArray: params[2]
-      },
-      {
-        to: defaultLocalAragonBases.apmAddress,
-        methodName: 'newRepoWithVersion',
-        shortName: 'test',
-        managerAddress,
-        versionArray: [1, 0, 0]
+  /**
+   * Test utility to fetch a repo state, its address and latest version
+   * @param appName
+   * @param provider
+   */
+  async function fetchRepoState(
+    _appName: string,
+    bre: BuidlerRuntimeEnvironment
+  ): Promise<RepoState> {
+    const networkConfig = bre.network.config as HttpNetworkConfig
+    const provider = new ethers.providers.Web3Provider(
+      bre.web3.currentProvider,
+      networkConfig.ensAddress && {
+        name: bre.network.name,
+        chainId: networkConfig.chainId || 5555,
+        ensAddress: networkConfig.ensAddress
       }
     )
-  })
+    const repoAddress = await provider.resolveName(_appName)
+    if (!repoAddress) throw Error(`No address found for ENS ${_appName}`)
+    const latestVersion = await getRepoVersion(repoAddress, 'latest', provider)
+    return {
+      repoAddress,
+      version: latestVersion.version,
+      contractAddress: latestVersion.contractAddress
+    }
+  }
 
-  it('Release contractAddress should be correct', function() {
-    const { params } = txData
-    assert(
-      isAddress(params[3]),
-      'Release contractAddress is not a valid address'
+  /**
+   * Test utility to assert that a tx data object is correct
+   * given an initial repo state an a release bump
+   * @param repoState
+   * @param bump
+   * @param rawTxData
+   */
+  async function assertPublishTxData(
+    repoState: RepoState,
+    bump: ReleaseType,
+    txData: PublishVersionTxData
+  ): Promise<void> {
+    const data = parseNewVersionTxData(txData)
+
+    assert.equal(data.to, repoState.repoAddress, 'Tx to must be repo address')
+    if (bump === 'major')
+      assert.notEqual(
+        data.contractAddress,
+        repoState.contractAddress,
+        'Version contract address must NOT be the same as last version'
+      )
+    else
+      assert.equal(
+        data.contractAddress,
+        repoState.contractAddress,
+        'Version contract address must be the same as last version'
+      )
+    assert.equal(
+      data.version,
+      semver.inc(repoState.version, bump),
+      `New version should be a ${bump} bump from last version ${repoState.version}`
     )
-  })
 
-  it('Release contentUri should be correct', async function() {
-    const { params } = txData
-    const contentUri = params[4]
+    await assertContentUri(data.contentUri)
+  }
 
+  /**
+   * Test utility to assert that the contentUri is correct by resolving its content
+   * @param contentUri
+   */
+  async function assertContentUri(contentUri: string): Promise<void> {
     const files = await resolveRepoContentUri(contentUri, { ipfsGateway })
-
     assert.deepInclude(
       files.manifest,
       { name: 'Test app', author: 'testing', description: 'Test app' },
@@ -91,9 +117,191 @@ describe(`Run publish task - ${testAppDir}`, function() {
       { path: 'contracts/TestContract.sol' },
       'artifact.json does not include expected data'
     )
+  }
+
+  /**
+   * Test util to fetch the root account
+   * @param bre
+   */
+  async function getRootAccount(
+    bre: BuidlerRuntimeEnvironment
+  ): Promise<string> {
+    return (await bre.web3.eth.getAccounts())[0]
+  }
+
+  /**
+   * Test util to broadcast a resulting txData
+   * @param txData
+   * @param bre
+   */
+  async function broadcastTxData(
+    txData: PublishVersionTxData,
+    bre: BuidlerRuntimeEnvironment
+  ): Promise<void> {
+    await bre.web3.eth.sendTransaction({
+      from: await getRootAccount(bre),
+      to: txData.to,
+      data: encodePublishVersionTxData(txData)
+    })
+  }
+
+  describe('On a local network', function() {
+    let rootAccount: string
+
+    useEnvironment(testAppDir, 'localhost')
+
+    before('Environment is loaded', function() {
+      if (!this.env) throw Error('No .env in this, is useEnvironment run?')
+    })
+
+    before('Fetch rootAccount', async function() {
+      rootAccount = await getRootAccount(this.env)
+    })
+
+    let closeGanache: (() => void) | undefined
+    before('Run a local testnet with bases', async function() {
+      const ganache = await startGanache(this.env)
+      closeGanache = ganache.close
+      await deployBases(this.env)
+    })
+
+    describe(`Repo does not exist, deploy new contract and repo for ${testAppDir}`, function() {
+      const bump: ReleaseType = 'major'
+
+      it('Run publish task', async function() {
+        const txData = await this.env.run(TASK_PUBLISH, {
+          bump,
+          // Manager must be the root account, to publish more test versions
+          managerAddress: rootAccount,
+          ipfsApiUrl
+        })
+
+        const {
+          to,
+          shortName,
+          managerAddress,
+          contractAddress,
+          version,
+          contentUri
+        } = parseNewRepoWithVersionTxData(txData)
+        // Compare with an object to see all of them at once
+        assert.deepEqual(
+          {
+            to,
+            shortName,
+            managerAddress,
+            version
+          },
+          {
+            to: defaultLocalAragonBases.apmAddress,
+            shortName: 'test',
+            managerAddress: rootAccount,
+            version: '1.0.0'
+          }
+        )
+
+        assert(
+          isAddress(contractAddress),
+          'Release contractAddress is not a valid address'
+        )
+
+        await assertContentUri(contentUri)
+
+        // Apply TX so it can be consumed by tests below
+        await broadcastTxData(txData, this.env)
+      })
+    })
+
+    describe('Repo exists, patch release with just content', function() {
+      const bump: ReleaseType = 'patch'
+      let repoState: RepoState
+
+      before('Fetch repo state', async function() {
+        repoState = await fetchRepoState(appName, this.env)
+      })
+
+      it('Run publish task', async function() {
+        const txData: PublishVersionTxData = await this.env.run(TASK_PUBLISH, {
+          bump,
+          ipfsApiUrl
+        })
+        await assertPublishTxData(repoState, bump, txData)
+
+        // Apply TX so it can be consumed by tests below
+        await broadcastTxData(txData, this.env)
+      })
+    })
+
+    describe('Repo exists, major release with contract and content', function() {
+      const bump: ReleaseType = 'major'
+      let repoState: RepoState
+
+      before('Fetch repo state', async function() {
+        repoState = await fetchRepoState(appName, this.env)
+      })
+
+      it('Run publish task', async function() {
+        const txData: PublishVersionTxData = await this.env.run(TASK_PUBLISH, {
+          bump,
+          ipfsApiUrl
+        })
+        await assertPublishTxData(repoState, bump, txData)
+
+        // Apply TX to check is valid
+        await broadcastTxData(txData, this.env)
+      })
+    })
+
+    after('Stop ganache instance', function() {
+      if (closeGanache) closeGanache()
+    })
   })
 
-  after('Stop ganache instance', function() {
-    if (closeGanache) closeGanache()
+  describe.skip('On the mainnet network', function() {
+    const appName = 'finance.aragonpm.eth'
+    const mainnetNetwork = 'mainnet'
+
+    useEnvironment(testAppDir, mainnetNetwork)
+
+    before('Environment is loaded', function() {
+      if (!this.env) throw Error('No .env in this, is useEnvironment run?')
+    })
+
+    before('Retrieve config', async function() {
+      const config = this.env.config.aragon as AragonConfig
+      assert.equal(
+        (config.appName || {})[mainnetNetwork] || config.appName,
+        appName,
+        'Wrong app name'
+      )
+    })
+
+    before('Make sure mainnet provider works', async function() {
+      try {
+        await this.env.web3.eth.getBlockNumber()
+      } catch (e) {
+        const url = (this.env.network.provider as any)._url
+        e.message = `Provider check error ${url}: ${e.message}`
+        throw e
+      }
+    })
+
+    let repoState: RepoState
+
+    before('Fetch repo state', async function() {
+      repoState = await fetchRepoState(appName, this.env)
+    })
+
+    describe('Repo exists, patch release with just content', function() {
+      const bump: ReleaseType = 'patch'
+
+      it('Run publish task', async function() {
+        const txData: PublishVersionTxData = await this.env.run(TASK_PUBLISH, {
+          bump,
+          ipfsApiUrl
+        })
+        await assertPublishTxData(repoState, bump, txData)
+      })
+    })
   })
 })

--- a/test/test-helpers/publishVersionTxParsers.ts
+++ b/test/test-helpers/publishVersionTxParsers.ts
@@ -1,0 +1,58 @@
+import { PublishVersionTxData } from '~/src/utils/apm'
+
+/**
+ * Test utility to parse tx data params
+ * @param txData
+ */
+export function parseNewVersionTxData(
+  txData: PublishVersionTxData
+): {
+  to: string
+  version: string
+  contractAddress: string
+  contentUri: string
+} {
+  const { to, methodName, params } = txData
+  if (methodName !== 'newVersion') throw Error(`methodName must be newVersion`)
+  const [versionArray, contractAddress, contentUri] = params
+  return {
+    to,
+    version: versionArray.join('.'),
+    contractAddress,
+    contentUri
+  }
+}
+
+/**
+ * Test utility to parse tx data params
+ * @param txData
+ */
+export function parseNewRepoWithVersionTxData(
+  txData: PublishVersionTxData
+): {
+  to: string
+  shortName: string
+  managerAddress: string
+  version: string
+  contractAddress: string
+  contentUri: string
+} {
+  const { to, methodName, params } = txData
+  if (methodName !== 'newRepoWithVersion')
+    throw Error(`methodName must be newRepoWithVersion`)
+  const [
+    shortName,
+    managerAddress,
+    versionArray,
+    contractAddress,
+    contentUri
+  ] = params
+  return {
+    to,
+    shortName,
+    managerAddress,
+    version: versionArray.join('.'),
+    contractAddress,
+    contentUri
+  }
+}


### PR DESCRIPTION
Addresses an item of https://github.com/aragon/buidler-aragon/issues/77

Extends the current unique publish test to 4 tests:
- localhost
  - Repo doesn't exist; deploys new contract and repo
  - Repo exists, do a minor or patch with just content changing
  - Repo exists, do a major with new contract and content
- mainnet (_skipped, may be unstable_)
  - Repo exists, do a minor or patch with just content changing