### PR TITLE
Fix url joinning bug

### DIFF
--- a/src/tasks/publish/prettyOutput.ts
+++ b/src/tasks/publish/prettyOutput.ts
@@ -1,10 +1,10 @@
-import path from 'path'
 import chalk from 'chalk'
 import {
   PublishVersionTxData,
   encodePublishVersionTxData
 } from '~/src/utils/apm'
 import { getAppNameParts } from '~/src/utils/appName'
+import { urlJoin } from '~/src/utils/url'
 
 /**
  * Returns a preview sumary of the publish tx with escape codes
@@ -55,7 +55,7 @@ export function getPrettyPublishTxPreview({
 
 ${list.print(2)}
 
-  ${chalk.cyan(path.join(ipfsGateway, 'ipfs', contentHash))}
+  ${chalk.cyan(urlJoin(ipfsGateway, 'ipfs', contentHash))}
 `
 }
 
@@ -95,7 +95,7 @@ ${list.print(2)}
   ${
     etherscanUrl
       ? `
-  ${chalk.cyan(path.join(etherscanUrl, 'tx', txHash))}
+  ${chalk.cyan(urlJoin(etherscanUrl, 'tx', txHash))}
   `
       : ''
   }`

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,10 @@
+/**
+ * Joins multiple url parts safely
+ * - Does not break the protocol double slash //
+ * - Cleans double slashes at any point
+ * @param args ("http://ipfs.io", "ipfs", "Qm")
+ * @return "http://ipfs.io/ipfs/Qm"
+ */
+export function urlJoin(...args: string[]): string {
+  return args.join('/').replace(/([^:]\/)\/+/g, '$1')
+}

--- a/test/src/utils/url.test.ts
+++ b/test/src/utils/url.test.ts
@@ -1,0 +1,10 @@
+import { assert } from 'chai'
+
+import { urlJoin } from '~/src/utils/url'
+
+describe('urlJoin', () => {
+  it('Should join url parts', () => {
+    const url = urlJoin('http://ipfs.io', 'ipfs', 'Qm')
+    assert.equal(url, 'http://ipfs.io/ipfs/Qm')
+  })
+})


### PR DESCRIPTION
Current implementation used `path.join` which breaks any URL