### PR TITLE
Detect working IPFS gateway and use it for tx details

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -77,6 +77,7 @@ export const defaultLocalAragonBases = {
 }
 
 export const defaultIpfsGateway = 'https://ipfs.eth.aragon.network'
+export const defaultIpfsApiUrl = 'http://localhost:5001'
 
 /**
  * Chain ids of networks that support Etherscan contract verification

--- a/src/tasks/publish/index.ts
+++ b/src/tasks/publish/index.ts
@@ -8,7 +8,8 @@ import {
   zeroAddress,
   etherscanSupportedChainIds,
   defaultIpfsGateway,
-  etherscanChainUrls
+  etherscanChainUrls,
+  defaultIpfsApiUrl
 } from '../../params'
 import execa from 'execa'
 import { TASK_COMPILE, TASK_VERIFY_CONTRACT, TASK_PUBLISH } from '../task-names'
@@ -114,10 +115,9 @@ async function publishTask(
   const distPath = aragonConfig.appBuildOutputPath as string
   const ignoreFilesPath = aragonConfig.ignoreFilesPath as string
   const selectedNetwork = bre.network.name
-  const ipfsApiUrl = ipfsApiUrlArg || (bre.config.ipfs || {}).ipfsApi
+  const ipfsApiUrl =
+    ipfsApiUrlArg || (bre.config.ipfs || {}).ipfsApi || defaultIpfsApiUrl
   // TODO: Warn the user their metadata files (e.g. appName) are not correct.
-
-  if (!ipfsApiUrl) throw new BuidlerPluginError(`ipfsApiUrl must be defined`)
 
   const appName = _parseAppNameFromConfig(aragonConfig.appName, selectedNetwork)
   const contractName = getMainContractName()

--- a/src/utils/ipfs/guessGatewayUrl.ts
+++ b/src/utils/ipfs/guessGatewayUrl.ts
@@ -1,0 +1,98 @@
+import fetch from 'node-fetch'
+import { uniq } from 'lodash'
+import { urlJoin, parseUrlSafe } from '../url'
+
+/**
+ * Returns a URL that may have a given content hash already available
+ * Use after publish to guess at which gateway URL the recently uploaded
+ * content is already available
+ *
+ * Possible gateway routes given a URL exposing an IPFS node are
+ * - mynode.io/ipfs/Qm...
+ * - mynode.io:8080/ipfs/Qm...
+ * - mynode.io:5001/ipfs/Qm...
+ */
+export async function guessGatewayUrl({
+  ipfsApiUrl,
+  contentHash,
+  ipfsGateway
+}: {
+  ipfsApiUrl: string
+  contentHash: string
+  ipfsGateway?: string
+}): Promise<string | null> {
+  const urls = getPossibleGatewayUrls({ ipfsApiUrl, ipfsGateway })
+  try {
+    return await oneSuccess<string>(
+      urls.map(async url => {
+        const testUrl = urlJoin(url, 'ipfs', contentHash)
+        const res = await fetch(testUrl, { timeout: 3000 })
+        // node-fetch does not throw on error status codes
+        if (!res.ok) throw Error(`Not ok ${res.statusText}`)
+        await res.text()
+        // If the request succeeds, return the url to be used as gateway
+        return url
+      })
+    )
+  } catch (e) {
+    // No Gateway URL works
+    return null
+  }
+}
+
+/**
+ * Aggregate a list of possible available gateway URLs given an API url and gateway
+ * - Some gateways are exposed in port 80 or 8080
+ * - The IPFS API has a gateway route, but it is closed in Infura's for example
+ * @return possibleGatewayUrls = [
+ *   'http://mynode.io/',
+ *   'http://mynode.io:5001/',
+ *   'http://mynode.io:6001/',
+ *   'http://mynode.io:8080/',
+ *   'https://ipfs.io'
+ * ]
+ */
+export function getPossibleGatewayUrls({
+  ipfsApiUrl,
+  ipfsGateway
+}: {
+  ipfsApiUrl: string
+  ipfsGateway?: string
+}): string[] {
+  const possibleUrls: string[] = []
+
+  const ipfsApiUrlParsed = parseUrlSafe(ipfsApiUrl)
+  // Add after parsing to ensure same formating
+  possibleUrls.push(ipfsApiUrlParsed.toString())
+  for (const port of ['', '5001', '8080']) {
+    ipfsApiUrlParsed.port = port
+    possibleUrls.push(ipfsApiUrlParsed.toString())
+  }
+
+  if (ipfsGateway) possibleUrls.push(ipfsGateway)
+
+  return uniq(possibleUrls).sort()
+}
+
+/**
+ * From https://stackoverflow.com/questions/37234191/how-do-you-implement-a-racetosuccess-helper-given-a-list-of-promises
+ * @param promises
+ */
+function oneSuccess<T>(promises: Promise<T>[]): Promise<T> {
+  return Promise.all(
+    promises.map(async p => {
+      // If a request fails, count that as a resolution so it will keep
+      // waiting for other possible successes. If a request succeeds,
+      // treat it as a rejection so Promise.all immediately bails out.
+      return p.then(
+        val => Promise.reject(val),
+        err => Promise.resolve(err)
+      )
+    })
+  ).then(
+    // If '.all' resolved, we've just got an array of errors.
+    errors => Promise.reject(errors),
+    // If '.all' rejected, we've got the result we wanted.
+    val => Promise.resolve(val)
+  )
+}

--- a/src/utils/ipfs/index.ts
+++ b/src/utils/ipfs/index.ts
@@ -1,2 +1,3 @@
 export * from './assertIpfsApiIsAvailable'
+export * from './guessGatewayUrl'
 export * from './uploadDirToIpfs'

--- a/src/utils/ipfs/uploadDirToIpfs.ts
+++ b/src/utils/ipfs/uploadDirToIpfs.ts
@@ -2,8 +2,6 @@ import IpfsHttpClient from 'ipfs-http-client'
 import path from 'path'
 const { globSource } = IpfsHttpClient
 
-const defaultIpfsApiUrl = 'http://localhost:5001'
-
 interface Cid {
   version: number
   codec: string
@@ -24,16 +22,18 @@ interface IpfsAddResult {
  * - .ipfsignore
  * - .gitignore
  */
-export async function uploadDirToIpfs(
-  dirPath: string,
-  options?: {
-    ipfsApiUrl?: string
-    ignore?: string[]
-    progress?: (totalBytes: number) => void
-  }
-): Promise<string> {
-  const { ipfsApiUrl, ignore, progress } = options || {}
-  const ipfs = IpfsHttpClient(ipfsApiUrl || defaultIpfsApiUrl)
+export async function uploadDirToIpfs({
+  dirPath,
+  ipfsApiUrl,
+  ignore,
+  progress
+}: {
+  dirPath: string
+  ipfsApiUrl: string
+  ignore?: string[]
+  progress?: (totalBytes: number) => void
+}): Promise<string> {
+  const ipfs = IpfsHttpClient(ipfsApiUrl)
 
   const results: IpfsAddResult[] = []
   for await (const entry of ipfs.add(

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -8,3 +8,19 @@
 export function urlJoin(...args: string[]): string {
   return args.join('/').replace(/([^:]\/)\/+/g, '$1')
 }
+
+/**
+ * Wrapps the URL module and accepts urls without a protocol
+ * assumes HTTP
+ * @param url
+ */
+export function parseUrlSafe(url: string): URL {
+  try {
+    return new URL(url)
+  } catch (e) {
+    if (!url.includes('://')) {
+      return new URL('http://' + url)
+    }
+    throw e
+  }
+}

--- a/test/src/utils/ipfs/guessGatewayUrl.test.ts
+++ b/test/src/utils/ipfs/guessGatewayUrl.test.ts
@@ -1,0 +1,35 @@
+import { assert } from 'chai'
+
+import { guessGatewayUrl, getPossibleGatewayUrls } from '~/src/utils/ipfs'
+import { infuraIpfsApiUrl } from '~/test/testParams'
+
+describe('guessGatewayUrl', () => {
+  describe('getPossibleGatewayUrls', () => {
+    it('Should return list of possible gateway urls', () => {
+      const ipfsApiUrl = 'http://mynode.io:6001'
+      const ipfsGateway = 'https://ipfs.io'
+      const urls = getPossibleGatewayUrls({ ipfsApiUrl, ipfsGateway })
+      assert.deepEqual(urls, [
+        'http://mynode.io/',
+        'http://mynode.io:5001/',
+        'http://mynode.io:6001/',
+        'http://mynode.io:8080/',
+        'https://ipfs.io'
+      ])
+    })
+  })
+
+  describe('guessGatewayUrl', () => {
+    it('Should return the available gateway', async () => {
+      const ipfsApiUrl = infuraIpfsApiUrl
+      const ipfsGateway = 'https://wrong.io'
+      const contentHash = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/about'
+      const url = await guessGatewayUrl({
+        ipfsApiUrl,
+        ipfsGateway,
+        contentHash
+      })
+      assert.equal(url, 'https://ipfs.infura.io/')
+    })
+  })
+})

--- a/test/src/utils/ipfs/uploadDirToIpfs.test.ts
+++ b/test/src/utils/ipfs/uploadDirToIpfs.test.ts
@@ -29,7 +29,7 @@ describe('uploadDirToIpfs', function() {
   })
 
   it('Should upload a test dir to IPFS and get the expected hash', async function() {
-    const res = await uploadDirToIpfs(testDir, { ipfsApiUrl })
+    const res = await uploadDirToIpfs({ dirPath: testDir, ipfsApiUrl })
     assert.equal(res, contentHash, 'hash of uploaded test dir has changed')
   })
 })


### PR DESCRIPTION
Given ` ipfsApiUrl = 'http://mynode.io:6001'` `ipfsGateway = 'https://mygateway.io'` a tries different commonly available gateways routes 
```
 *   'http://mynode.io/',
 *   'http://mynode.io:5001/',
 *   'http://mynode.io:6001/',
 *   'http://mynode.io:8080/',
 *   'https://mygateway.io'
```
to check which one has already the provided `contentHash`.

This help solve the problem where the content uploaded to `ipfsApiUrl` will not be immediately available in `ipfsGateway` creating a bad UX.

In normal conditions running `guessGatewayUrl` takes 600ms, and since it has timeout it will take 3s in the worst-case scenario. Internally uses a custom Promise race which returns on the first success or on all rejects.