### PR TITLE
Add IPFS sanity check before uploading

### DIFF
--- a/src/tasks/publish/index.ts
+++ b/src/tasks/publish/index.ts
@@ -14,7 +14,7 @@ import execa from 'execa'
 import { TASK_COMPILE, TASK_VERIFY_CONTRACT, TASK_PUBLISH } from '../task-names'
 import { logMain } from '../../ui/logger'
 import { AragonConfig } from '~/src/types'
-import { uploadDirToIpfs } from '~/src/utils/ipfs'
+import { uploadDirToIpfs, assertIpfsApiIsAvailable } from '~/src/utils/ipfs'
 import createIgnorePatternFromFiles from './createIgnorePatternFromFiles'
 import parseAndValidateBumpOrVersion from './parseAndValidateBumpOrVersion'
 import { getMainContractName } from '../../utils/arappUtils'
@@ -135,6 +135,10 @@ async function publishTask(
     prevVersion ? prevVersion.version : undefined
   )
   logMain(`Applying version bump ${bump}, next version: ${nextVersion}`)
+
+  // Do sanity checks before compiling the contract or uploading files
+  // So users do not have to wait a long time before seeing the config is not okay
+  await assertIpfsApiIsAvailable(ipfsApiUrl)
 
   // Using let + if {} block instead of a ternary operator
   // to assign value and log status to console

--- a/src/utils/ipfs/assertIpfsApiIsAvailable.ts
+++ b/src/utils/ipfs/assertIpfsApiIsAvailable.ts
@@ -1,0 +1,17 @@
+import IpfsHttpClient from 'ipfs-http-client'
+import { BuidlerPluginError } from '@nomiclabs/buidler/plugins'
+
+/**
+ * Sanity check to check if an IPFS API is active
+ * Note: It requires the API to /api/v0/version route available
+ */
+export async function assertIpfsApiIsAvailable(
+  ipfsApiUrl: string
+): Promise<void> {
+  const ipfs = IpfsHttpClient(ipfsApiUrl)
+  try {
+    await ipfs.version()
+  } catch (e) {
+    throw new BuidlerPluginError(`IPFS API at ${ipfsApiUrl} is not available`)
+  }
+}

--- a/src/utils/ipfs/index.ts
+++ b/src/utils/ipfs/index.ts
@@ -1,1 +1,2 @@
+export * from './assertIpfsApiIsAvailable'
 export * from './uploadDirToIpfs'


### PR DESCRIPTION
Make sure the IPFS API URL provided is active by calling `/api/v0/version`

Do sanity checks before compiling the contract or uploading files. So users do not have to wait a long time before seeing the config is not okay