### PR TITLE
Add permissions sanity check

### DIFF
--- a/src/tasks/publish/index.ts
+++ b/src/tasks/publish/index.ts
@@ -116,6 +116,7 @@ async function publishTask(
 
   const appName = _parseAppNameFromConfig(aragonConfig.appName, selectedNetwork)
   const contractName = getMainContractName()
+  const rootAccount = await getRootAccount(bre)
 
   // Initialize clients
   const networkConfig = bre.network.config as HttpNetworkConfig
@@ -139,6 +140,8 @@ async function publishTask(
   // Do sanity checks before compiling the contract or uploading files
   // So users do not have to wait a long time before seeing the config is not okay
   await assertIpfsApiIsAvailable(ipfsApiUrl)
+
+  await apm.assertCanPublish(appName, rootAccount, provider)
 
   // Using let + if {} block instead of a ternary operator
   // to assign value and log status to console
@@ -183,7 +186,6 @@ async function publishTask(
     contentUri: apm.toContentUri('ipfs', contentHash)
   }
 
-  const rootAccount = await getRootAccount(bre)
   const network = await provider.getNetwork()
   if (!managerAddress) managerAddress = rootAccount
   const txData = await apm.publishVersion(appName, versionInfo, provider, {

--- a/src/utils/apm/abis.ts
+++ b/src/utils/apm/abis.ts
@@ -1,5 +1,7 @@
 export const apmRegistryAbi = [
   'function newRepoWithVersion(string _name, address _dev, uint16[3] _initialSemanticVersion, address _contractAddress, bytes _contentURI) public returns (address)',
+  'function CREATE_REPO_ROLE() view returns (bytes32)',
+  'function canPerform(address, bytes32, uint256[]) external view returns (bool)',
   'event NewRepo(bytes32 id, string name, address repo)'
 ]
 
@@ -7,6 +9,8 @@ export const repoAbi = [
   'function newVersion(uint16[3] _newSemanticVersion, address _contractAddress, bytes _contentURI)',
   'function getLatest() public view returns (uint16[3] semanticVersion, address contractAddress, bytes contentURI)',
   'function getBySemanticVersion(uint16[3] _semanticVersion) public view returns (uint16[3] semanticVersion, address contractAddress, bytes contentURI)',
+  'function CREATE_VERSION_ROLE() view returns (bytes32)',
+  'function canPerform(address, bytes32, uint256[]) external view returns (bool)',
   'event NewVersion(uint256 versionId, uint16[3] semanticVersion)'
 ]
 

--- a/src/utils/apm/assertCanPublish.ts
+++ b/src/utils/apm/assertCanPublish.ts
@@ -1,0 +1,48 @@
+import { ethers } from 'ethers'
+import * as repo from './repo'
+import { apmRegistryAbi } from './abis'
+import { getAppNameParts } from '../appName'
+import { BuidlerPluginError } from '@nomiclabs/buidler/plugins'
+
+/**
+ * Asserts that a sender has permissions to publish a new version / repo
+ * Otherwise will throw an error with a detailed message
+ * @param appName "finance.aragonpm.eth"
+ * @param sender Account attempting to publish "0xE04cAbcB24e11620Dd62bB99c396E76cEB578914"
+ * @param provider Initialized ethers provider
+ */
+export async function assertCanPublish(
+  appName: string,
+  sender: string,
+  provider: ethers.providers.Provider
+): Promise<void> {
+  const repoAddress = await provider.resolveName(appName)
+
+  if (repoAddress) {
+    // If the repo exists, check if user has create version role
+    const isAllowed = await repo.canPublishVersion(appName, sender, provider)
+    if (!isAllowed)
+      throw new BuidlerPluginError(
+        `Account ${sender} does not have permissions to publish a new version in ${appName}`
+      )
+  } else {
+    // If the repo does not exist yet, create a repo with the first version
+    const { registryName } = getAppNameParts(appName)
+    const registryAddress = await provider.resolveName(registryName)
+
+    if (!registryAddress)
+      throw new BuidlerPluginError(`Registry ${registryName} does not exist`)
+
+    const registry = new ethers.Contract(
+      registryAddress,
+      apmRegistryAbi,
+      provider
+    )
+    const CREATE_REPO_ROLE = await registry.CREATE_REPO_ROLE()
+    const isAllowed = await registry.canPerform(sender, CREATE_REPO_ROLE, [])
+    if (!isAllowed)
+      throw new BuidlerPluginError(
+        `Account ${sender} does not have permissions to create a new repo ${registryName}`
+      )
+  }
+}

--- a/src/utils/apm/index.ts
+++ b/src/utils/apm/index.ts
@@ -1,4 +1,5 @@
 export * from './abis'
+export * from './assertCanPublish'
 export * from './publishVersion'
 export * from './repo'
 export * from './resolveContent'

--- a/src/utils/apm/repo.ts
+++ b/src/utils/apm/repo.ts
@@ -53,3 +53,19 @@ export function getRepoVersion(
   const repo = _getRepoInstance(repoNameOrAddress, provider)
   return _getRepoVersion(repo, version)
 }
+
+/**
+ * Returns true if the address can publish a new version to this repo
+ * @param repoNameOrAddress "finance", "finance.aragonpm.eth", "0xa600c17..."
+ * @param sender Account attempting to publish "0xE04cAbcB24e11620Dd62bB99c396E76cEB578914"
+ * @param provider Initialized ethers provider
+ */
+export async function canPublishVersion(
+  repoNameOrAddress: string,
+  sender: string,
+  provider: ethers.providers.Provider
+): Promise<boolean> {
+  const repo = _getRepoInstance(repoNameOrAddress, provider)
+  const CREATE_VERSION_ROLE = await repo.CREATE_VERSION_ROLE()
+  return await repo.canPerform(sender, CREATE_VERSION_ROLE, [])
+}

--- a/test/src/utils/apm/assertCanPublish.test.ts
+++ b/test/src/utils/apm/assertCanPublish.test.ts
@@ -1,0 +1,51 @@
+import { assert } from 'chai'
+import { assertCanPublish } from '~/src/utils/apm'
+import { getMainnetProvider } from '~/test/test-helpers/providers'
+import { zeroAddress } from '~/src/params'
+import { BuidlerPluginError } from '@nomiclabs/buidler/plugins'
+
+describe('apm > assertCanPublish', () => {
+  const provider = getMainnetProvider()
+  const financeManager = '0xE04cAbcB24e11620Dd62bB99c396E76cEB578914'
+  const testCases: {
+    [appName: string]: {
+      [sender: string]: boolean // expected isAllowed
+    }
+  } = {
+    'finance.aragonpm.eth': {
+      [financeManager]: true,
+      [zeroAddress]: false
+    },
+    'newapp.aragonpm.eth': {
+      [financeManager]: true,
+      [zeroAddress]: false
+    },
+    'newapp.open.aragonpm.eth': {
+      [financeManager]: true,
+      [zeroAddress]: true
+    }
+  }
+
+  describe(`Test can publish with mainnet apps`, () => {
+    for (const [appName, senders] of Object.entries(testCases))
+      for (const [sender, expectedIsAllowed] of Object.entries(senders))
+        it(`${sender} should ${
+          expectedIsAllowed ? 'be' : 'not be'
+        } able to publish ${appName}`, async () => {
+          const isAllowed = await assertCanPublish(
+            appName,
+            sender,
+            provider
+          ).then(
+            () => true,
+            // Wrap function to return a binary true / false for expected errors only
+            e => {
+              if (e instanceof BuidlerPluginError) return false
+              else throw e
+            }
+          )
+
+          assert.equal(isAllowed, expectedIsAllowed, 'Wrong isAllowed return')
+        })
+  })
+})

--- a/test/src/utils/apm/repo.test.ts
+++ b/test/src/utils/apm/repo.test.ts
@@ -1,13 +1,14 @@
 import { assert } from 'chai'
-import { getRepoVersion, ApmVersion } from '~/src/utils/apm'
+import { getRepoVersion, canPublishVersion, ApmVersion } from '~/src/utils/apm'
 import { getMainnetProvider } from '~/test/test-helpers/providers'
+import { zeroAddress } from '~/src/params'
 
 describe('apm > repo', () => {
-  describe('Return an existing version of a repo', () => {
-    const provider = getMainnetProvider()
+  const provider = getMainnetProvider()
+  const appName = 'finance.aragonpm.eth'
 
+  describe('Return an existing version of a repo', () => {
     it('first finance.aragonpm.eth version in mainnet', async () => {
-      const appName = 'finance.aragonpm.eth'
       const version = '1.0.0'
 
       // Since it's requesting a fixed version, it's safe
@@ -19,6 +20,29 @@ describe('apm > repo', () => {
         contentUri: 'ipfs:QmWWNkXdGDnTaxAxw6vtCM21SDJeWLyaoUzDb3skYXynmo'
       }
       assert.deepEqual(versionData, expectedVersionData, 'wrong versionData')
+    })
+  })
+
+  describe('Publish version permissions', () => {
+    const allowedSender = '0xE04cAbcB24e11620Dd62bB99c396E76cEB578914'
+    const notAllowedSender = zeroAddress
+
+    it('Allowed address should be able to publish', async () => {
+      const canPerform = await canPublishVersion(
+        appName,
+        allowedSender,
+        provider
+      )
+      assert.isTrue(canPerform, 'canPerform should be true')
+    })
+
+    it('Not allowed address should not be able to publish', async () => {
+      const canPerform = await canPublishVersion(
+        appName,
+        notAllowedSender,
+        provider
+      )
+      assert.isFalse(canPerform, 'canPerform should be false')
     })
   })
 })


### PR DESCRIPTION
**Requires https://github.com/aragon/buidler-aragon/pull/101 to be merged before, then rebase this one on develop**

Make sure the root account has permissions to either create a new version or a new repo

Do sanity checks before compiling the contract or uploading files. So users do not have to wait a long time before seeing the config is not okay