### PR TITLE
Remove kovan from default Aragon public nodes

### DIFF
--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -46,11 +46,6 @@ const defaultNetworks: Networks = {
     gas: 6.9e6,
     gasPrice: 15000000001
   },
-  kovan: {
-    chainId: 42,
-    url: aragonRpc('kovan'),
-    gas: 6.9e6
-  },
   coverage: {
     url: coverageRpc,
     gas: 0xffffffffff,


### PR DESCRIPTION
```
lion@lion-gram:~/Code/aragon$ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":67}' https://kovan.eth.aragon.network
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```