### PR TITLE
Standarize appName usage across the entire plugin

### DIFF
--- a/src/config/aragon.ts
+++ b/src/config/aragon.ts
@@ -1,6 +1,5 @@
 import { ConfigExtender } from '@nomiclabs/buidler/types'
 import { AragonConfig } from '~/src/types'
-import { readArappIfExists } from '~/src/utils/arappUtils'
 
 export const defaultAragonConfig: AragonConfig = {
   appServePort: 8001,
@@ -16,38 +15,5 @@ export const configExtender: ConfigExtender = (finalConfig, userConfig) => {
   finalConfig.aragon = {
     ...defaultAragonConfig,
     ...(userConfig.aragon || {})
-  }
-
-  // Fetch network specific app names from arapp.json
-  const arapp = readArappIfExists()
-  if (arapp && typeof arapp.environments === 'object') {
-    const appNames: { [network: string]: string } = {}
-    for (const [network, env] of Object.entries(arapp.environments)) {
-      if (env.appName) appNames[network] = env.appName
-    }
-
-    const userAppName = (userConfig.aragon || {}).appName
-    const appNamesArr = Object.values(appNames)
-    const thereAreNames = appNamesArr.length > 0
-    const allNamesAreEqual = appNamesArr.every(name => name === appNamesArr[0])
-    if (thereAreNames) {
-      if (allNamesAreEqual) {
-        // Only add it if it's not defined in the buidler.config
-        if (!userAppName) {
-          finalConfig.aragon.appName = appNamesArr[0]
-        }
-      } else {
-        finalConfig.aragon.appName = {
-          ...appNames,
-          // Merge buidler config app names if any
-          // If there's one single appName add it as "default"
-          ...(typeof userAppName === 'object'
-            ? userAppName
-            : typeof userAppName === 'string'
-            ? { default: userAppName }
-            : {})
-        }
-      }
-    }
   }
 }

--- a/src/tasks/publish/index.ts
+++ b/src/tasks/publish/index.ts
@@ -23,7 +23,11 @@ import { logMain } from '~/src/ui/logger'
 import * as apm from '~/src/utils/apm'
 import { getRootAccount } from '~/src/utils/accounts'
 import { getFullAppName } from '~/src/utils/appName'
-import { getMainContractName } from '~/src/utils/arappUtils'
+import {
+  getMainContractName,
+  readArapp,
+  parseAppName
+} from '~/src/utils/arappUtils'
 import { generateArtifacts, validateArtifacts } from '~/src/utils/artifact'
 import {
   uploadDirToIpfs,
@@ -125,7 +129,8 @@ async function publishTask(
 
   // TODO: Warn the user their metadata files (e.g. appName) are not correct.
 
-  const appName = _parseAppNameFromConfig(aragonConfig.appName, selectedNetwork)
+  const arapp = readArapp()
+  const appName = parseAppName(arapp, selectedNetwork)
   const contractName = getMainContractName()
   const rootAccount = await getRootAccount(bre)
 
@@ -317,36 +322,4 @@ async function _getChainId(bre: BuidlerRuntimeEnvironment): Promise<number> {
   const provider = new ethers.providers.Web3Provider(bre.web3.currentProvider)
   const net = await provider.getNetwork()
   return net.chainId
-}
-
-/**
- * Utility to parse appName from the aragon config
- * @param appNameOrObj
- * @param network
- */
-function _parseAppNameFromConfig(
-  appNameOrObj: string | { [network: string]: string } | undefined,
-  network: string
-): string {
-  switch (typeof appNameOrObj) {
-    case 'string':
-      if (!appNameOrObj)
-        throw new BuidlerPluginError(
-          `appName must not be empty in buidler.config`
-        )
-      return appNameOrObj
-
-    case 'object':
-      if (!appNameOrObj[network])
-        throw new BuidlerPluginError(
-          `No appName defined for network '${network}' in buidler.config`
-        )
-      else return appNameOrObj[network]
-
-    default:
-      throw new BuidlerPluginError(
-        `appName is buidler.config is of type ${typeof appNameOrObj}
-It must a string or an object { [network]: appName}`
-      )
-  }
 }

--- a/src/tasks/start/backend/update-app.ts
+++ b/src/tasks/start/backend/update-app.ts
@@ -2,12 +2,20 @@ import Web3 from 'web3'
 import { BuidlerRuntimeEnvironment } from '@nomiclabs/buidler/types'
 import { RepoInstance, KernelInstance } from '~/typechain'
 import { deployImplementation } from './deploy-implementation'
+import { getAppId } from '~/src/utils/appName'
 
 export async function updateApp(
-  appId: string,
-  dao: KernelInstance,
-  repo: RepoInstance,
-  appServePort: number,
+  {
+    appName,
+    dao,
+    repo,
+    appServePort
+  }: {
+    appName: string
+    dao: KernelInstance
+    repo: RepoInstance
+    appServePort: number
+  },
   bre: BuidlerRuntimeEnvironment
 ): Promise<{
   implementationAddress: string
@@ -25,7 +33,10 @@ export async function updateApp(
   )
 
   // Update the proxy with the new implementation.
-  await _updateProxy(implementation.address, appId, dao, bre.web3)
+  await _updateProxy(
+    { implementationAddress: implementation.address, appName, dao },
+    bre.web3
+  )
 
   return { implementationAddress: implementation.address, version, uri }
 }
@@ -34,12 +45,19 @@ export async function updateApp(
  * Updates the app proxy's implementation in the Kernel.
  */
 async function _updateProxy(
-  implementationAddress: string,
-  appId: string,
-  dao: KernelInstance,
+  {
+    implementationAddress,
+    appName,
+    dao
+  }: {
+    implementationAddress: string
+    appName: string
+    dao: KernelInstance
+  },
   web3: Web3
 ): Promise<void> {
   const rootAccount: string = (await web3.eth.getAccounts())[0]
+  const appId = getAppId(appName)
 
   // Set the new implementation in the Kernel.
   await dao.setApp(

--- a/src/tasks/start/start-backend.ts
+++ b/src/tasks/start/start-backend.ts
@@ -25,10 +25,8 @@ import { startGanache } from './backend/start-ganache'
  * be used with an Aragon client to view the app.
  */
 export async function startBackend(
-  bre: BuidlerRuntimeEnvironment,
-  appName: string,
-  appId: string,
-  silent: boolean
+  { appName, silent }: { appName: string; silent: boolean },
+  bre: BuidlerRuntimeEnvironment
 ): Promise<{
   daoAddress: string
   appAddress: string
@@ -93,14 +91,7 @@ export async function startBackend(
   // Note: This creates the proxy, but doesn't
   // initialize it yet.
   logBack('Creating app...')
-  const { proxy, repo } = await createApp(
-    appName,
-    appId,
-    dao,
-    ensAddress,
-    apmAddress,
-    bre
-  )
+  const { proxy, repo } = await createApp({ appName, dao, ensAddress }, bre)
   logBack(`Proxy address: ${proxy.address}`)
   logBack(`Repo address: ${repo.address}`)
 
@@ -126,11 +117,9 @@ export async function startBackend(
   }
 
   // Update app.
+  const appServePort = config.appServePort as number
   const { implementationAddress, version } = await updateApp(
-    appId,
-    dao,
-    repo,
-    config.appServePort as number,
+    { appName, dao, repo, appServePort },
     bre
   )
   logBack(`Implementation address: ${implementationAddress}`)
@@ -181,10 +170,7 @@ export async function startBackend(
       // Update app.
       logBack('Updating app...')
       const { implementationAddress, version } = await updateApp(
-        appId,
-        dao,
-        repo,
-        config.appServePort as number,
+        { appName, dao, repo, appServePort },
         bre
       )
       logBack(`Implementation address: ${implementationAddress}`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,15 +17,6 @@ export interface AragonConfig {
   appSrcPath?: string
   appBuildOutputPath?: string
   ignoreFilesPath?: string
-  /**
-   * If the appName is different per network use object form
-   * ```ts
-   * appName: {
-   *   rinkeby: "myapp.open.aragonpm.eth"
-   * }
-   * ```
-   */
-  appName?: string | { [network: string]: string }
 
   /**
    * IPFS gateway, to fetch static files such as the artifact
@@ -171,6 +162,17 @@ export interface AragonAppJson {
       params: string // '*'
     }[]
   }[]
+  /**
+   * If the appName is different per network use environments
+   * ```ts
+   * environments: {
+   *   rinkeby: {
+   *     appName: "myapp.open.aragonpm.eth"
+   *   }
+   * }
+   * ```
+   */
+  appName?: string
 }
 
 export interface AragonEnvironments {

--- a/src/utils/arappUtils.ts
+++ b/src/utils/arappUtils.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { BuidlerPluginError } from '@nomiclabs/buidler/plugins'
-import { AragonAppJson, AragonEnvironment } from '~/src/types'
-import { readJson, readJsonIfExists } from './fsUtils'
+import { AragonAppJson } from '~/src/types'
+import { pathExists, readJson, readJsonIfExists } from './fsUtils'
 
 const arappPath = 'arapp.json'
 const contractsPath = './contracts'
@@ -12,6 +12,10 @@ const contractsPath = './contracts'
  * @return AragonAppJson
  */
 export function readArapp(): AragonAppJson {
+  if (!pathExists(arappPath))
+    throw new BuidlerPluginError(
+      `No ${arappPath} found in current working directory\n ${process.cwd()}`
+    )
   return readJson(arappPath)
 }
 
@@ -21,40 +25,6 @@ export function readArapp(): AragonAppJson {
  */
 export function readArappIfExists(): AragonAppJson | undefined {
   return readJsonIfExists(arappPath)
-}
-
-/**
- * Returns app ens name.
- * @param network "mainnet"
- * @return "voting.open.aragonpm.eth"
- */
-export function getAppEnsName(network = 'default'): string {
-  const arapp = readArapp()
-
-  const environment: AragonEnvironment | undefined =
-    arapp.environments[network] || arapp.environments['default']
-  if (!environment) {
-    throw new BuidlerPluginError(`Default environemnt not found in arapp.json.`)
-  }
-
-  const appEnsName = (environment || {}).appName
-  if (!appEnsName)
-    throw new BuidlerPluginError(
-      `No appName found. You need to setup one for the environment ${environment} in the arapp.json file.`
-    )
-
-  return appEnsName
-}
-
-/**
- * Returns app name.
- * @param network "mainnet"
- * @return "voting"
- */
-export function getAppName(network = 'default'): string {
-  const ensName = getAppEnsName(network)
-
-  return (ensName || '').split('.')[0]
 }
 
 /**
@@ -89,4 +59,49 @@ export function getMainContractPath(): string {
 export function getMainContractName(): string {
   const mainContractPath: string = getMainContractPath()
   return path.parse(mainContractPath).name
+}
+
+/**
+ * Parse the appName from arapp.json in a flexible manner
+ * @param arapp
+ * @param network
+ */
+export function parseAppName(arapp: AragonAppJson, network?: string): string {
+  if (!arapp.appName && !arapp.environments)
+    throw new BuidlerPluginError(
+      `No appName configured. 
+Add an 'appName' property in your arapp.json with your app's ENS name`
+    )
+
+  // Aggreate app names from environments
+  const appNameByNetwork: { [network: string]: string } = {}
+  for (const [_network, env] of Object.entries(arapp.environments)) {
+    if (env.appName) appNameByNetwork[_network] = env.appName
+  }
+
+  // If there an appName for that network return it
+  if (network && appNameByNetwork[network]) return appNameByNetwork[network]
+
+  // If there's a default appName return it
+  if (arapp.appName) {
+    return arapp.appName
+  } else {
+    // Otherwise, try to guess the appName
+
+    // Pre-compute booleans to make logic below readable
+    const appNamesArr = Object.values(appNameByNetwork)
+    const thereAreNames = appNamesArr.length > 0
+    const allNamesAreEqual = appNamesArr.every(name => name === appNamesArr[0])
+
+    if (thereAreNames && allNamesAreEqual) return appNamesArr[0]
+
+    // If no guess was possible ask the user to provide it
+    const networkId = network || 'development' // Don't print "undefined" for development
+    throw new BuidlerPluginError(
+      `No appName configured for network ${networkId}. 
+Add an 'appName' property in the environment of ${networkId} with your app's 
+ENS name in your arapp.json. If your app's name is the name accross networks,
+Add an 'appName' property in your arapp.json with your app's ENS name`
+    )
+  }
 }

--- a/src/utils/artifact/generateArtifacts.ts
+++ b/src/utils/artifact/generateArtifacts.ts
@@ -3,11 +3,7 @@ import { TASK_FLATTEN_GET_FLATTENED_SOURCE } from '@nomiclabs/buidler/builtin-ta
 import { BuidlerRuntimeEnvironment } from '@nomiclabs/buidler/types'
 import { artifactName, manifestName, flatCodeName } from '~/src/params'
 import { AragonManifest, AbiItem } from '~/src/types'
-import {
-  getMainContractName,
-  readArapp,
-  getAppEnsName
-} from '~/src/utils/arappUtils'
+import { getMainContractName, readArapp } from '~/src/utils/arappUtils'
 import { readJson, writeJson, writeFile, ensureDir } from '~/src/utils/fsUtils'
 import { generateAragonArtifact } from './generateAragonArtifact'
 
@@ -26,7 +22,6 @@ export async function generateArtifacts(
   const arapp = readArapp()
   const manifest = readJson<AragonManifest>(manifestName)
   const contractName: string = getMainContractName()
-  const appEnsName = getAppEnsName(bre.network.name)
 
   // buidler will detect and throw for cyclic dependencies
   // any flatten task also compiles
@@ -34,13 +29,7 @@ export async function generateArtifacts(
   // Get ABI from generated artifacts in compilation
   const abi = _readArtifact(contractName, bre).abi
 
-  const artifact = generateAragonArtifact(
-    appEnsName,
-    arapp,
-    abi,
-    flatCode,
-    contractName
-  )
+  const artifact = generateAragonArtifact(arapp, abi, flatCode, contractName)
   ensureDir(outPath)
   writeJson(path.join(outPath, artifactName), artifact)
   writeJson(path.join(outPath, manifestName), manifest)

--- a/src/utils/ens.ts
+++ b/src/utils/ens.ts
@@ -1,0 +1,31 @@
+import {
+  BuidlerRuntimeEnvironment,
+  HttpNetworkConfig
+} from '@nomiclabs/buidler/types'
+import { ethers } from 'ethers'
+
+/**
+ * Resolve ENS name with custom ensAddress
+ * @param name
+ * @param bre
+ * @param customEnsAddress
+ */
+export async function resolveName(
+  {
+    name,
+    ensAddress
+  }: {
+    name: string
+    ensAddress: string
+  },
+  bre: BuidlerRuntimeEnvironment
+): Promise<string | undefined> {
+  const networkConfig = bre.network.config as HttpNetworkConfig
+
+  const provider = new ethers.providers.Web3Provider(bre.web3.currentProvider, {
+    name: bre.network.name,
+    chainId: networkConfig.chainId || 5555,
+    ensAddress
+  })
+  return provider.resolveName(name)
+}

--- a/test/src/tasks/publish-task.test.ts
+++ b/test/src/tasks/publish-task.test.ts
@@ -1,7 +1,6 @@
 import { assert } from 'chai'
 import { useEnvironment } from '~/test/test-helpers/useEnvironment'
 import { TASK_PUBLISH } from '~/src/tasks/task-names'
-import { AragonConfig } from '~/src/types'
 import { startGanache } from '~/src/tasks/start/backend/start-ganache'
 import deployBases from '~/src/tasks/start/backend/bases/deploy-bases'
 import {
@@ -23,6 +22,7 @@ import {
   HttpNetworkConfig
 } from '@nomiclabs/buidler/types'
 import { getRootAccount } from '~/src/utils/accounts'
+import { readArapp, parseAppName } from '~/src/utils/arappUtils'
 
 interface RepoState {
   repoAddress: string
@@ -222,12 +222,8 @@ describe('Publish task', function() {
     })
 
     before('Retrieve config', async function() {
-      const config = this.env.config.aragon as AragonConfig
-      assert.equal(
-        (config.appName || {})[mainnetNetwork] || config.appName,
-        appName,
-        'Wrong app name'
-      )
+      const arapp = readArapp()
+      assert.equal(parseAppName(arapp), appName, 'Wrong app name')
     })
 
     before('Make sure mainnet provider works', async function() {

--- a/test/src/tasks/start/backend/create-app.test.ts
+++ b/test/src/tasks/start/backend/create-app.test.ts
@@ -11,8 +11,9 @@ import {
   startGanache,
   stopGanache
 } from '~/src/tasks/start/backend/start-ganache'
-import { readArapp, getAppEnsName, getAppName } from '~/src/utils/arappUtils'
+import { readArapp, parseAppName } from '~/src/utils/arappUtils'
 import { getAppId } from '~/src/utils/appName'
+import { AragonAppJson } from '~/src/types'
 
 describe('create-app.ts', function() {
   // Note: These particular tests use localhost instead of buidlerevm.
@@ -20,27 +21,25 @@ describe('create-app.ts', function() {
   // And because we want to restart the chain on certain tests.
   useEnvironment('counter', 'localhost')
 
-  let ensAddress, apmAddress, daoFactoryAddress
-  let appName, appId
+  let arapp: AragonAppJson, appName: string
+  let ensAddress, daoFactoryAddress
   let dao
+
+  before('Read arapp in test folder after useEnviornment chdir', () => {
+    arapp = readArapp()
+    appName = parseAppName(arapp)
+  })
 
   before('start ganache', async function() {
     await startGanache(this.env)
   })
 
   before('deploy bases', async function() {
-    ;({ ensAddress, apmAddress, daoFactoryAddress } = await deployBases(
-      this.env
-    ))
+    ;({ ensAddress, daoFactoryAddress } = await deployBases(this.env))
   })
 
   before('deploy a dao', async function() {
     dao = await createDao(this.env.web3, this.env.artifacts, daoFactoryAddress)
-  })
-
-  before('calculate appName and appId', async function() {
-    appName = getAppName()
-    appId = getAppId(getAppEnsName())
   })
 
   after('stop ganache', async function() {
@@ -52,11 +51,7 @@ describe('create-app.ts', function() {
 
     before('create app', async function() {
       ;({ proxy, repo, implementation } = await createApp(
-        appName,
-        appId,
-        dao,
-        ensAddress,
-        apmAddress,
+        { appName, dao, ensAddress },
         this.env
       ))
 
@@ -76,6 +71,7 @@ describe('create-app.ts', function() {
     })
 
     it('dao references the correct implementation for it', async function() {
+      const appId = getAppId(appName)
       assert.equal(
         implementation.address,
         await dao.getApp(await dao.APP_BASES_NAMESPACE(), appId),
@@ -89,7 +85,7 @@ describe('create-app.ts', function() {
 
     it('reverts when attempting to create the app again', async function() {
       await assertRevert(
-        createApp(appName, appId, dao, ensAddress, apmAddress, this.env),
+        createApp({ appName, dao, ensAddress }, this.env),
         'KERNEL_INVALID_APP_CHANGE'
       )
     })

--- a/test/src/tasks/start/backend/set-permissions.test.ts
+++ b/test/src/tasks/start/backend/set-permissions.test.ts
@@ -10,8 +10,8 @@ import {
   startGanache,
   stopGanache
 } from '~/src/tasks/start/backend/start-ganache'
-import { readArapp, getAppEnsName, getAppName } from '~/src/utils/arappUtils'
-import { getAppId } from '~/src/utils/appName'
+import { readArapp, parseAppName } from '~/src/utils/arappUtils'
+import { AragonAppJson } from '~/src/types'
 
 describe('set-permissions.ts', function() {
   // Note: These particular tests use localhost instead of buidlerevm.
@@ -19,19 +19,22 @@ describe('set-permissions.ts', function() {
   // And because we want to restart the chain on certain tests.
   useEnvironment('counter', 'localhost')
 
-  let ensAddress, apmAddress, daoFactoryAddress
-  let appName, appId
+  let arapp: AragonAppJson, appName: string
+  let ensAddress, daoFactoryAddress
   let dao, acl
   let proxy
+
+  before('Read arapp in test folder after useEnviornment chdir', () => {
+    arapp = readArapp()
+    appName = parseAppName(arapp)
+  })
 
   before('start ganache', async function() {
     await startGanache(this.env)
   })
 
   before('deploy bases', async function() {
-    ;({ ensAddress, apmAddress, daoFactoryAddress } = await deployBases(
-      this.env
-    ))
+    ;({ ensAddress, daoFactoryAddress } = await deployBases(this.env))
   })
 
   before('deploy a dao and retrieve acl', async function() {
@@ -41,20 +44,8 @@ describe('set-permissions.ts', function() {
     acl = await ACL.at(await dao.acl())
   })
 
-  before('calculate appName and appId', async function() {
-    appName = getAppName()
-    appId = getAppId(getAppEnsName())
-  })
-
   before('create app', async function() {
-    ;({ proxy } = await createApp(
-      appName,
-      appId,
-      dao,
-      ensAddress,
-      apmAddress,
-      this.env
-    ))
+    ;({ proxy } = await createApp({ appName, dao, ensAddress }, this.env))
 
     await proxy.initialize()
   })

--- a/test/src/tasks/start/backend/update-app.test.ts
+++ b/test/src/tasks/start/backend/update-app.test.ts
@@ -11,8 +11,9 @@ import {
   startGanache,
   stopGanache
 } from '~/src/tasks/start/backend/start-ganache'
-import { getAppEnsName, getAppName, readArapp } from '~/src/utils/arappUtils'
+import { readArapp, parseAppName } from '~/src/utils/arappUtils'
 import { getAppId } from '~/src/utils/appName'
+import { AragonAppJson } from '~/src/types'
 
 describe('update-app.ts', function() {
   // Note: These particular tests use localhost instead of buidlerevm.
@@ -20,27 +21,25 @@ describe('update-app.ts', function() {
   // And because we want to restart the chain on certain tests.
   useEnvironment('counter', 'localhost')
 
-  let ensAddress, apmAddress, daoFactoryAddress
-  let appName, appId
+  let arapp: AragonAppJson, appName: string
+  let ensAddress, daoFactoryAddress
   let dao
+
+  before('Read arapp in test folder after useEnviornment chdir', () => {
+    arapp = readArapp()
+    appName = parseAppName(arapp)
+  })
 
   before('start ganache', async function() {
     await startGanache(this.env)
   })
 
   before('deploy bases', async function() {
-    ;({ ensAddress, apmAddress, daoFactoryAddress } = await deployBases(
-      this.env
-    ))
+    ;({ ensAddress, daoFactoryAddress } = await deployBases(this.env))
   })
 
   before('deploy a dao', async function() {
     dao = await createDao(this.env.web3, this.env.artifacts, daoFactoryAddress)
-  })
-
-  before('calculate appName and appId', async function() {
-    appName = getAppName()
-    appId = getAppId(getAppEnsName())
   })
 
   after('stop ganache', async function() {
@@ -52,11 +51,7 @@ describe('update-app.ts', function() {
 
     before('create app', async function() {
       ;({ proxy, repo, implementation } = await createApp(
-        appName,
-        appId,
-        dao,
-        ensAddress,
-        apmAddress,
+        { appName, dao, ensAddress },
         this.env
       ))
 
@@ -85,10 +80,7 @@ describe('update-app.ts', function() {
         // Appears to be a caching issue with truffle/ganache.
         await this.env.run(TASK_COMPILE)
         ;({ implementationAddress, version, uri } = await updateApp(
-          appId,
-          dao,
-          repo,
-          port,
+          { appName, dao, repo, appServePort: port },
           this.env
         ))
       })
@@ -98,6 +90,7 @@ describe('update-app.ts', function() {
       })
 
       it('the dao references the correct implementation for it', async function() {
+        const appId = getAppId(appName)
         assert.equal(
           implementationAddress,
           await dao.getApp(await dao.APP_BASES_NAMESPACE(), appId),

--- a/test/src/utils/arappUtils.test.ts
+++ b/test/src/utils/arappUtils.test.ts
@@ -2,8 +2,6 @@ import { assert } from 'chai'
 import {
   getMainContractName,
   getMainContractPath,
-  getAppName,
-  getAppEnsName,
   readArapp
 } from '~/src/utils/arappUtils'
 import { useDefaultEnvironment } from '~/test/test-helpers/useEnvironment'
@@ -14,14 +12,6 @@ describe('arapp.ts', function() {
   it('should read an arapp.json file', async function() {
     const arapp = await readArapp()
     assert(arapp != null)
-  })
-
-  it('should retrieve app name', async function() {
-    assert.equal(await getAppName(), 'counter')
-  })
-
-  it('should retrieve app ens-name', async function() {
-    assert.equal(await getAppEnsName(), 'counter.aragonpm.eth')
   })
 
   it('should retrieve the correct main contract path', function() {

--- a/test/src/utils/artifact/generateAragonArtifact.test.ts
+++ b/test/src/utils/artifact/generateAragonArtifact.test.ts
@@ -16,7 +16,6 @@ describe('ast > generateAragonArtifact', () => {
     if (arapp && flatCode && artifact) {
       it(`Should generate artifact.json - ${appName}`, () => {
         const newArtifact = generateAragonArtifact(
-          'mainnet',
           arapp,
           artifact.abi,
           flatCode,


### PR DESCRIPTION
Current code had a lot of ambiguity of whether the variable `appName` was "counter", "counter.aragonpm.eth" or "0xa4a4a4" (appId). This is a potentially strong source of bugs and was causing inconsistencies already.

This PR
- makes sure all variables containing name information are `appName` = "counter.aragonpm.eth" (full ENS domain), and each function will derive variations in its body if applicable.
- All functions use a single utility `parseAppName` to derive the `appName` from `arapp.json`
- The start task is more robust allowing any appName from whatever registry

