### PR TITLE
Add Github templates and scaffolding from CLI but re-worded

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+## 👉 [Please follow one of these issue templates](https://github.com/aragon/buidler-aragon/issues/new/choose) 👈
+
+Note: to keep the backlog clean and actionable, issues may be immediately closed if they do not follow one of the above issue templates.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,59 @@
+---
+name: 🐛 Bug Report
+about: Submit a bug report to help us improve
+labels: bug
+---
+
+## 🐛 Bug Report
+
+(A clear and concise description of what the bug is)
+
+### Have you read the [Contributing Guidelines on issues](https://github.com/aragon/buidler-aragon/blob/master/CONTRIBUTING.md#ways-to-contribute)?
+
+- [ ] Yes
+
+## To Reproduce
+
+<!-- Write your steps here: -->
+
+1. In aragon app '...'
+2. Run command '....'
+3. Then did '....'
+4. See error
+
+## Expected behavior
+
+<!--
+  How did you expect your project to behave?
+  It’s fine if you’re not sure your understanding is correct.
+  Just write down what you thought would happen.
+-->
+
+(Write what you thought would happen.)
+
+## Actual Behavior
+
+<!--
+  Did something go wrong?
+  Is something broken, or not behaving as you expected?
+  Describe this section in detail, and attach screenshots if possible.
+  Don't just say "it doesn't work"!
+-->
+
+(Write what happened. Add screenshots, if applicable.)
+
+## Context
+
+#### Network and buidler.config?
+
+(Which network you are using the app with.)
+
+#### Aragon App project?
+
+(Enter the Github URL of your project if it's public)
+
+#### Environment
+
+- OS and OS version: [e.g. Linux Mint 18.0]
+- NodeJS and buidler version
+- Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -48,7 +48,7 @@ labels: bug
 
 (Which network you are using the app with.)
 
-#### Aragon App project?
+#### Aragon app project?
 
 (Enter the Github URL of your project if it's public)
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,13 @@
+---
+name: 📚 Documentation
+about: Report an issue related to documentation
+labels: docs
+---
+
+## 📚 Documentation
+
+(A clear and concise description of what the issue is.)
+
+### Have you read the [Contributing Guidelines on issues](https://github.com/aragon/buidler-aragon/blob/master/CONTRIBUTING.md#ways-to-contribute)?
+
+(Write your answer here.)

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,21 @@
+---
+name: 🚀 Feature
+about: Submit a proposal/request for a new feature
+labels: enhancement
+---
+
+## 🚀 Feature
+
+(A clear and concise description of what the feature is. Include any alternative solutions or features you've considered.)
+
+## Have you read the [Contributing Guidelines on issues](https://github.com/aragon/buidler-aragon/blob/master/CONTRIBUTING.md#ways-to-contribute)?
+
+(Write your answer here.)
+
+## Motivation
+
+(Please outline the motivation for the proposal.)
+
+## Pitch
+
+(Please explain why this feature should be implemented and how it would be used. Add any other context or screenshots about the feature request here.)

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,0 +1,12 @@
+---
+name: 💥 Proposal
+about: Propose a non-trivial change to buidler-aragon
+---
+
+## 💥 Proposal
+
+(A clear and concise description of what the proposal is.)
+
+### Have you read the [Contributing Guidelines on issues](https://github.com/aragon/buidler-aragon/blob/master/CONTRIBUTING.md#ways-to-contribute)?
+
+(Write your answer here.)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -11,4 +11,4 @@ Please contact us instead. We have a few channels:
 
 - [Aragon Hack](https://hack.aragon.org/docs)
 - [Aragon Forum](https://forum.aragon.org)
-- [Aragon Chat](https://aragon.chat)
+- [Aragon Chat](https://spectrum.chat/aragon)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,14 @@
+---
+name: ❓ Questions/Help
+about: If you have questions, please check Aragon Hack, Aragon Forum or Aragon Chat
+---
+
+## ❓ Questions and Help
+
+### Please note that this issue tracker is not a help form and this issue will be closed.
+
+Please contact us instead. We have a few channels:
+
+- [Aragon Hack](https://hack.aragon.org/docs)
+- [Aragon Forum](https://forum.aragon.org)
+- [Aragon Chat](https://aragon.chat)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+# 🦅 Pull Request Description
+
+<!-- Pull request description and links to related issues -->
+
+## Rational
+
+<!-- Please explain the reasoning behind your changed -->
+
+## 🚨 Test instructions
+
+<!-- In case it is difficult or not straightforward to test this change,
+please provide test instructions! -->
+
+## ✔️ PR Todo
+
+- [ ] Include links to related issues/PRs
+- [ ] Update unit tests for this change
+- [ ] Update the relevant documentation
+- [ ] Clear dependencies on other modules that have to be released before merging this
+
+<!--
+Thank you for contributing!
+
+To help us review this change in a timely manner, please make sure to read and follow the
+[CONTRIBUTING](https://github.com/aragon/buidler-aragon/blob/master/CONTRIBUTING.md) guidelines.
+-->

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,12 @@
+# Configuration for https://probot.github.io/apps/welcome
+
+newIssueWelcomeComment: >
+  Thanks for opening your first issue in aragonCLI! Someone will circle back soon ⚡
+
+newPRWelcomeComment: >
+  Thanks for opening this pull request! Someone will review it soon 🔍
+
+firstPRMergeComment: >
+  Congrats on merging your first pull request! Aragon is proud of you 🦅
+
+  ![Eagle gif](https://media.giphy.com/media/SLD8eKFPuUDuw/200w_d.gif)

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,17 @@
+# Configuration for https://probot.github.io/apps/release-drafter
+
+name-template: v$NEXT_PATCH_VERSION
+tag-template: v$NEXT_PATCH_VERSION
+categories:
+  - title: 🚀 New features
+    label: 🚀 new feature
+  - title: 💡 Feature updates
+    label: 💡 feature update
+  - title: 🐛 Bug Fixes
+    label: 🐛 bug
+  - title: 🛠️ Maintenance (non-API changes)
+    label: 🛠️ maintenance
+template: |
+  ### What’s changed in buidler-aragon
+
+  $CHANGES

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,20 +1,12 @@
 # Configuration for https://probot.github.io/apps/stale
 
-daysUntilStale: 60
-daysUntilClose: 7
-
+only: pulls
 staleLabel: abandoned
-
-issues:
-  daysUntilStale: 180
-  markComment: >
-    This issue has been automatically marked as stale because it has not had
-    recent activity. It will be closed if no further activity occurs. Thank you
-    for contributing to Aragon! 🦅
 
 pulls:
   daysUntilStale: 30
+  daysUntilClose: 7
   markComment: >
     This pull request has been automatically marked as stale because it has not had
     recent activity. It will be closed if no further activity occurs. Thank you
-    for contributing to Aragon! 🦅 
+    for contributing to Aragon! 🦅

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Configuration for https://probot.github.io/apps/stale
+
+daysUntilStale: 60
+daysUntilClose: 7
+
+staleLabel: abandoned
+
+issues:
+  daysUntilStale: 180
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for contributing to Aragon! 🦅
+
+pulls:
+  daysUntilStale: 30
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for contributing to Aragon! 🦅 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing to buidler-aragon
+
+:tada: Thank you for being interested in contributing to an Aragon Project! :tada:
+
+Feel welcome and read the following sections in order to know how to ask questions and how to work on something.
+
+All members of our community are expected to follow our [Code of Conduct](https://wiki.aragon.org/documentation/Code_of_Conduct/). Please make sure you are welcoming and friendly in all of our spaces.
+
+## Get Rewarded
+
+We are starting to experiment with bounties using the very same tools we are building in Aragon. In particular the [Projects app](https://www.autark.xyz/projects-app) of The Planning Suite made by Autark team.
+
+Look for the [💰funded](https://github.com/aragon/buidler-aragon/issues?q=is%3Aissue+is%3Aopen+label%3A%22💰+funded%22) label on issues and ask the mantainers to guide you through the bounty workflow.
+
+You will apply to the boutnies on our own DAO, [follow the link to explore it.](https://rinkeby.aragon.org/#/meshteam/0x2b2290c2370cbc59e7c77bd36072f801d5e996c8)
+
+We will create a guide shortly with a walkthrough the whole process. Stay tuned 🙌
+
+## Get Involved
+
+There are many ways to contribute to Aragon, and many of them do not involve writing any code. Here's a few ideas to get started:
+
+- Does everything work as expected? If not, we're always looking for improvements. Let us know by [opening an issue](#reporting-new-issues).
+- Look through the [open issues](https://github.com/aragon/buidler-aragon/issues). Provide workarounds, ask for clarification, or suggest labels.
+- If you find an issue you would like to fix, [open a pull request](#your-first-code-contribution). Issues tagged as [_Good first issue_](https://github.com/aragon/buidler-aragon/issues?q=is%3Aissue+is%3Aopen+label%3A%22%3Apray%3A+good+first+issue%22) are a good place to get started.
+- Read through [Aragon documentation](https://hack.aragon.org/docs). If you find anything that is confusing or can be improved, you can make edits by clicking "Edit" at the top of most docs.
+- Take a look at the [features requested](https://github.com/aragon/buidler-aragon/issues?q=is%3Aissue+is%3Aopen+label%3A%22🚀+new+feature%22) by others in the community and consider opening a pull request if you see something you want to work on.
+
+Contributions are very welcome.
+
+## Ways to Contribute
+
+We use [GitHub Issues](https://github.com/aragon/buidler-aragon/issues) for our public bugs. If you would like to report a problem, take a look around and see if someone already opened an issue about it. If you a are certain this is a new, unreported bug, you can submit a [bug report](#reporting-new-issues).
+
+You can also file issues as [feature requests or enhancements](https://github.com/aragon/buidler-aragon/issues?q=is%3Aissue+is%3Aopen+label%3A%22🚀+new+feature%22). If you see anything you'd like to be implemented, create an issue with [feature template](https://raw.githubusercontent.com/aragon/buidler-aragon/master/.github/ISSUE_TEMPLATE/feature.md).
+
+Do your best to include as many details as needed in order for someone else to fix the problem and resolve the issue.
+
+### Reporting new issues
+
+When [opening a new issue](https://github.com/aragon/buidler-aragon/issues/new/choose), always make sure to fill out the issue template. **This step is very important!**
+
+- **One issue, one bug:** Please report a single bug per issue.
+- **Provide reproduction steps:** List all the steps necessary to reproduce the issue. The person reading your bug report should be able to follow these steps to reproduce your issue with minimal effort.
+
+### Fix an issue
+
+You can browse our [issue tracker](https://github.com/aragon/buidler-aragon/issues) and choose an issue to fix. The development process follows one typical of open source contributions. Here's a quick rundown:
+
+1. [Find an issue](https://github.com/aragon/buidler-aragon/issues) that you are interested in addressing or a feature that you would like to add.
+2. Fork the repository to your local GitHub organization. This means that you will have a copy of the repository under `your-GitHub-username/hack`.
+3. Clone the repository to your local machine using `git clone https://github.com/github-username/buidler-aragon.git`.
+4. Create a new branch for your fix using `git checkout -b branch-name-here`.
+5. Make the appropriate changes for the issue you are trying to address or the feature that you want to add.
+6. Use `git add insert-paths-of-changed-files-here` to add the file contents of the changed files to the "snapshot" git uses to manage the state of the project, also known as the index.
+7. Use `git commit -m "Insert a short message of the changes made here"` to store the contents of the index with a descriptive message.
+8. Push the changes to the remote repository using `git push origin branch-name-here`.
+9. Submit a pull request in github to the upstream repository.
+10. Title the pull request with a short description of the changes made and the issue or bug number associated with your change. For example, you can use a title like "Added more log outputting to resolve #4352".
+11. In the description of the pull request, explain the changes that you made, any issues you think exist with the pull request you made, and any questions you have for the maintainer. It's OK if your pull request is not perfect (no pull request is). The reviewer will be able to help you fix any problems and improve it!
+12. Wait for the pull request to be reviewed by a maintainer.
+13. Make changes to the pull request if the maintainer recommends them.
+14. Celebrate your success after your pull request is merged by making some noise in the #dev channel! :tada:
+
+## Your First Code Contribution
+
+So you have decided to contribute code back to upstream by opening a pull request. You've invested a good chunk of time, and we appreciate it. We will do our best to work with you and get the PR looked at.
+
+Working on your first Pull Request? You can learn how from this free video series:
+
+[**How to Contribute to an Open Source Project on GitHub**](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
+
+Unsure where to begin contributing? You can start by looking through these `good first issue` issues:
+
+- [Good first issue](https://github.com/aragon/buidler-aragon/labels/%3Apray%3A%20good%20first%20issue) - issues which should only require a few lines of code, and a test or two.
+
+## Getting help
+
+If you need help, please reach out to Aragon core contributors and community members in the [#dev-help channel](https://aragon.chat/channel/dev-help) on the Aragon Chat. We'd love to hear from you and know what you're working on!
+
+## Style Guide
+
+[Prettier](https://prettier.io) and [ESLint](https://eslint.org) will catch most styling and linting issues that may exist in your code.
+
+## Semantic Commit Messages
+
+See how a minor change to your commit message style can make you a better programmer.
+
+Format: `<type>(<scope>): <subject>`
+
+`<scope>` is optional
+
+### Example
+
+```
+feat: allow overriding of webpack config
+^--^  ^------------^
+|     |
+|     +-> Summary in present tense.
+|
++-------> Type: chore, docs, feat, fix, refactor, style, or test.
+```
+
+The various types of commits:
+
+- `feat`: (new feature for the user, not a new feature for build script)
+- `fix`: (bug fix for the user, not a fix to a build script)
+- `docs`: (changes to the documentation)
+- `style`: (formatting, missing semi colons, etc; no production code change)
+- `refactor`: (refactoring production code, eg. renaming a variable)
+- `test`: (adding missing tests, refactoring tests; no production code change)
+- `chore`: (updating grunt tasks etc; no production code change)
+
+### Rules
+
+- Use lower case not title case!
+- Use the present tense ("Add feature" not "Added feature")
+- Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+- Limit the first line to 72 characters or less
+- Reference issues and pull requests liberally after the first line

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,16 +6,6 @@ Feel welcome and read the following sections in order to know how to ask questio
 
 All members of our community are expected to follow our [Code of Conduct](https://wiki.aragon.org/documentation/Code_of_Conduct/). Please make sure you are welcoming and friendly in all of our spaces.
 
-## Get Rewarded
-
-We are starting to experiment with bounties using the very same tools we are building in Aragon. In particular the [Projects app](https://www.autark.xyz/projects-app) of The Planning Suite made by Autark team.
-
-Look for the [💰funded](https://github.com/aragon/buidler-aragon/issues?q=is%3Aissue+is%3Aopen+label%3A%22💰+funded%22) label on issues and ask the mantainers to guide you through the bounty workflow.
-
-You will apply to the boutnies on our own DAO, [follow the link to explore it.](https://rinkeby.aragon.org/#/meshteam/0x2b2290c2370cbc59e7c77bd36072f801d5e996c8)
-
-We will create a guide shortly with a walkthrough the whole process. Stay tuned 🙌
-
 ## Get Involved
 
 There are many ways to contribute to Aragon, and many of them do not involve writing any code. Here's a few ideas to get started:
@@ -76,7 +66,7 @@ Unsure where to begin contributing? You can start by looking through these `good
 
 ## Getting help
 
-If you need help, please reach out to Aragon core contributors and community members in the [#dev-help channel](https://aragon.chat/channel/dev-help) on the Aragon Chat. We'd love to hear from you and know what you're working on!
+If you need help, please reach out to Aragon core contributors and community members in the [#dev-help channel](https://spectrum.chat/aragon) on the Aragon Chat. We'd love to hear from you and know what you're working on!
 
 ## Style Guide
 


### PR DESCRIPTION
While sections like contributing may be outdated due to Mesh re-structuring adding these files is much better than having nothing.

Remembering back to my first contribution, this templates are extremely helpful on the first contact with the codebase