### PR TITLE
Use @solidity-parser/parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "report-coverage": "codecov"
   },
   "dependencies": {
+    "@solidity-parser/parser": "^0.6.0",
     "chalk": "^3.0.0",
     "chokidar": "^3.3.1",
     "ethers": "^4.0.46",
@@ -46,7 +47,6 @@
     "live-server": "^1.2.1",
     "node-fetch": "^2.6.0",
     "open": "^7.0.0",
-    "solidity-parser-antlr": "^0.4.11",
     "source-map-support": "^0.5.16",
     "tcp-port-used": "^1.0.1",
     "tsconfig-paths": "^3.9.0"

--- a/src/utils/ast/parseContractFunctions.ts
+++ b/src/utils/ast/parseContractFunctions.ts
@@ -1,6 +1,6 @@
 import { keyBy } from 'lodash'
 import path from 'path'
-import * as parser from 'solidity-parser-antlr'
+import * as parser from '@solidity-parser/parser'
 import { parseFunctionsNotices } from './parseFunctionNotices'
 import { AragonContractFunction } from './types'
 import { coerceFunctionSignature } from './utils'
@@ -209,7 +209,7 @@ export function parseContractFunctions(
       contracts[contracts.length - 1]
   )
 
-  // # Pending: Curent solidity-parser-antlr version does not parse notices
+  // # Pending: Curent @solidity-parser/parser version does not parse notices
   // which are parsed here separately using regex against the source string
   // Functions are mapped with each other on a best effort using their
   // guessed signature, which may be wrong if complex syntax is used

--- a/src/utils/ast/parseContructor.ts
+++ b/src/utils/ast/parseContructor.ts
@@ -1,4 +1,4 @@
-import * as parser from 'solidity-parser-antlr'
+import * as parser from '@solidity-parser/parser'
 
 /**
  * Returns true if a contract has a constructor, otherwise false.

--- a/src/utils/ast/parseGlobalVariableAssignments.ts
+++ b/src/utils/ast/parseGlobalVariableAssignments.ts
@@ -1,4 +1,4 @@
-import * as parser from 'solidity-parser-antlr'
+import * as parser from '@solidity-parser/parser'
 
 /**
  * Finds global storage variable declarations with initialized values, e.g 'int a = 1'.

--- a/yarn.lock
+++ b/yarn.lock
@@ -360,6 +360,11 @@
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.5.2.tgz#4d74670ead39e4f4fdab605a393ba8ea2390a2c4"
   integrity sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ==
 
+"@solidity-parser/parser@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.6.0.tgz#deb964a4dbb8c21a342ee35b4acefb505fd04ea1"
+  integrity sha512-RiJXfS22frulogcfQCFhbKrd5ATu6P4tYUv/daChiIh6VHyKQ1kkVZVfX6aP7c2YGU/Bf9RwGNKdwLjfpaoqYQ==
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -8512,11 +8517,6 @@ solc@0.5.15:
     require-from-string "^2.0.0"
     semver "^5.5.0"
     tmp "0.0.33"
-
-solidity-parser-antlr@^0.4.11:
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz#af43e1f13b3b88309a875455f5d6e565b05ee5f1"
-  integrity sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg==
 
 sort-keys-length@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
`@solidity-parser/parser` is a fork of the original great work in https://github.com/federicobond/solidity-parser-antlr. 

While with the current base apps this change has no impact it may have for very new solidity features. 

As a rule of thumb we will use the parser used in by buidler/core https://github.com/nomiclabs/buidler/blob/d6e897c61730bd5b4a9ca1ae00df8aa65401ea75/packages/buidler-core/package.json#L75