### PR TITLE
Allow repos without app folder

### DIFF
--- a/src/config/aragon.ts
+++ b/src/config/aragon.ts
@@ -5,7 +5,6 @@ import { defaultIpfsGateway } from '~/src/params'
 export const defaultAragonConfig: AragonConfig = {
   appServePort: 8001,
   clientServePort: 3000,
-  appSrcPath: 'app/',
   appBuildOutputPath: 'dist/',
   ignoreFilesPath: '.',
   ipfsGateway: defaultIpfsGateway

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -11,7 +11,7 @@ const aragonRpc = (network: string): string =>
   `https://${network}.eth.aragon.network`
 const localRpc = 'http://localhost:8545'
 const coverageRpc = 'http://localhost:8555'
-const frameRpc = 'ws://localhost:1248'
+const frameRpc = 'http://localhost:1248'
 const frameOrigin = 'BuidlerAragon'
 
 const aragenNetwork: NetworkConfig = {

--- a/src/tasks/publish/index.ts
+++ b/src/tasks/publish/index.ts
@@ -212,7 +212,8 @@ you may use a public IPFS API such as
   // Generate and validate Aragon artifacts, release files
   logMain(`Generating Aragon app artifacts`)
   await generateArtifacts(distPath, bre)
-  if (!force) validateArtifacts(distPath)
+  const hasFrontend = appSrcPath ? true : false
+  if (!force) validateArtifacts(distPath, hasFrontend)
 
   // Upload release directory to IPFS
   logMain('Uploading release assets to IPFS...')

--- a/src/tasks/publish/index.ts
+++ b/src/tasks/publish/index.ts
@@ -73,6 +73,7 @@ export function setupPublishTask(): void {
       'Prevents contract compilation, deployment and artifact generation.'
     )
     .addFlag('verify', 'Automatically verify contract on Etherscan.')
+    .addFlag('force', 'Force publish without artifacts validation.')
     .addFlag('dryRun', 'Output tx data without broadcasting')
     .setAction(
       async (
@@ -88,6 +89,7 @@ export function setupPublishTask(): void {
             ipfsApiUrl: params.ipfsApiUrl,
             onlyContent: params.onlyContent,
             verify: params.verify,
+            force: params.force,
             dryRun: params.dryRun
           },
           bre
@@ -104,6 +106,7 @@ async function publishTask(
     ipfsApiUrl: ipfsApiUrlArg,
     onlyContent,
     verify,
+    force,
     dryRun
   }: {
     bumpOrVersion: string
@@ -112,6 +115,7 @@ async function publishTask(
     ipfsApiUrl: string
     onlyContent: boolean
     verify: boolean
+    force: boolean
     dryRun: boolean
   },
   bre: BuidlerRuntimeEnvironment
@@ -200,15 +204,15 @@ you may use a public IPFS API such as
     logMain(`Reusing previous version contract address: ${contractAddress}`)
   }
 
-  // Prepare release directory
-  // npm run build must create: index.html, src.js, script.js
-  logMain(`Building app front-end at ${appSrcPath}`)
-  await execa('npm', ['run', 'build'], { cwd: appSrcPath })
+  if (appSrcPath) {
+    logMain(`Running app build script`)
+    await execa('npm', ['run', 'build'], { cwd: appSrcPath })
+  }
 
   // Generate and validate Aragon artifacts, release files
   logMain(`Generating Aragon app artifacts`)
   await generateArtifacts(distPath, bre)
-  validateArtifacts(distPath)
+  if (!force) validateArtifacts(distPath)
 
   // Upload release directory to IPFS
   logMain('Uploading release assets to IPFS...')

--- a/src/utils/artifact/findMissingManifestFiles.ts
+++ b/src/utils/artifact/findMissingManifestFiles.ts
@@ -22,25 +22,27 @@ export function findMissingManifestFiles(
   const missingFiles: MissingFile[] = []
 
   function assertFile(filepath: string, id: string, required: boolean): void {
-    // filepath maybe a remote URL, ignore those cases
-    if (filepath.includes('://')) return
-    const fullPath = path.join(distPath, filepath)
-    if (!fs.existsSync(fullPath))
-      missingFiles.push({ path: fullPath, id, required })
+    if (filepath) {
+      // filepath maybe a remote URL, ignore those cases
+      if (filepath.includes('://')) return
+      const fullPath = path.join(distPath, filepath)
+      if (!fs.existsSync(fullPath))
+        missingFiles.push({ path: fullPath, id, required })
+    }
   }
 
   // Assert optional metadata
-  if (manifest.details_url) assertFile(manifest.details_url, 'details', false)
-  manifest.icons.forEach((icon, i) => {
-    assertFile(icon.src, `icon ${i}`, false)
-  })
-  manifest.screenshots.forEach((screenshot, i) => {
-    assertFile(screenshot.src, `screenshot ${i}`, false)
-  })
-
-  // Assert mandatory files
-  assertFile(manifest.start_url, 'start page', true)
-  assertFile(manifest.script, 'script', true)
+  assertFile(manifest.details_url, 'details', false)
+  manifest.icons &&
+    manifest.icons.forEach((icon, i) => {
+      assertFile(icon.src, `icon ${i}`, false)
+    })
+  manifest.screenshots &&
+    manifest.screenshots.forEach((screenshot, i) => {
+      assertFile(screenshot.src, `screenshot ${i}`, false)
+    })
+  assertFile(manifest.start_url, 'start page', false)
+  assertFile(manifest.script, 'script', false)
 
   return missingFiles
 }

--- a/src/utils/artifact/findMissingManifestFiles.ts
+++ b/src/utils/artifact/findMissingManifestFiles.ts
@@ -17,14 +17,14 @@ interface MissingFile {
  */
 export function findMissingManifestFiles(
   manifest: AragonManifest,
-  distPath: string
+  distPath: string,
+  hasFrontend: boolean
 ): MissingFile[] {
   const missingFiles: MissingFile[] = []
 
   function assertFile(filepath: string, id: string, required: boolean): void {
-    if (filepath) {
+    if (filepath && filepath.includes('://')) {
       // filepath maybe a remote URL, ignore those cases
-      if (filepath.includes('://')) return
       const fullPath = path.join(distPath, filepath)
       if (!fs.existsSync(fullPath))
         missingFiles.push({ path: fullPath, id, required })
@@ -41,8 +41,8 @@ export function findMissingManifestFiles(
     manifest.screenshots.forEach((screenshot, i) => {
       assertFile(screenshot.src, `screenshot ${i}`, false)
     })
-  assertFile(manifest.start_url, 'start page', false)
-  assertFile(manifest.script, 'script', false)
+  assertFile(manifest.start_url, 'start page', hasFrontend)
+  assertFile(manifest.script, 'script', hasFrontend)
 
   return missingFiles
 }

--- a/src/utils/artifact/validateArtifacts.ts
+++ b/src/utils/artifact/validateArtifacts.ts
@@ -33,7 +33,9 @@ Some files declared in manifest.json are not found in dist dir: ${distPath}
 ${missingFiles.map(file => ` - ${file.id}: ${file.path}`).join('\n')}
       
 Make sure your app build process includes them in the dist directory on
-every run of the designated NPM build script
+every run of the designated NPM build script.
+
+If you are sure you want to publish anyway, use the flag "--force".
 `
     )
 
@@ -44,6 +46,8 @@ every run of the designated NPM build script
       `
 Some contract roles do not match declared roles in ${arappName}:
 ${roleMatchErrors.map(err => ` - ${err.id}: ${err.message}`).join('\n')}
+
+If you are sure you want to publish anyway, use the flag "--force".
 `
     )
 }

--- a/src/utils/artifact/validateArtifacts.ts
+++ b/src/utils/artifact/validateArtifacts.ts
@@ -17,7 +17,10 @@ import { matchContractRoles } from './matchContractRoles'
  * - Make sure contract roles match arapp.json roles
  * - Make sure filepaths in the manifest exist
  */
-export function validateArtifacts(distPath: string): void {
+export function validateArtifacts(
+  distPath: string,
+  hasFrontend: boolean
+): void {
   // Load files straight from the dist directory
   const artifact = readJson<AragonArtifact>(path.join(distPath, artifactName))
   const manifest = readJson<AragonManifest>(path.join(distPath, manifestName))
@@ -25,7 +28,7 @@ export function validateArtifacts(distPath: string): void {
   const functions = parseContractFunctions(flatCode, artifact.path)
 
   // Make sure all declared files in the manifest are there
-  const missingFiles = findMissingManifestFiles(manifest, distPath)
+  const missingFiles = findMissingManifestFiles(manifest, distPath, hasFrontend)
   if (missingFiles.length)
     throw new BuidlerPluginError(
       `


### PR DESCRIPTION
# 🦅 Pull Request Description

Allow repos without an `app` folder.
Add `force` flag to force publish without validating artifacts.
Use Frame with http.

