### PR TITLE
Use correct network configuration from arapp.json

### DIFF
--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -83,10 +83,11 @@ export const configExtender: ConfigExtender = (finalConfig, userConfig) => {
         if (network.registry) {
           finalNetwork.ensAddress = network.registry
         }
-
-        // Create an alias of the declared network to an existing network
-        if (network.network !== networkName)
-          finalConfig.networks[networkName] = finalNetwork
+      } else if (network.network && finalConfig.networks[network.network]) {
+        finalConfig.networks[networkName] = {
+          ...finalConfig.networks[network.network],
+          ...(network.registry ? { ensAddress: network.registry } : {})
+        } as HttpNetworkConfig
       }
     }
   }

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -71,11 +71,12 @@ export const configExtender: ConfigExtender = (finalConfig, userConfig) => {
 
   // Apply networks from arapp.json
   const arapp = readArappIfExists()
+
   if (arapp && typeof arapp.environments === 'object') {
     for (const [networkName, network] of Object.entries(arapp.environments)) {
-      if (network.network && finalConfig.networks[network.network]) {
+      if (finalConfig.networks[networkName]) {
         const finalNetwork = finalConfig.networks[
-          network.network
+          networkName
         ] as HttpNetworkConfig
 
         // Append registry address

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -87,7 +87,7 @@ export const configExtender: ConfigExtender = (finalConfig, userConfig) => {
         finalConfig.networks[networkName] = {
           ...finalConfig.networks[network.network],
           ...(network.registry ? { ensAddress: network.registry } : {})
-        } as HttpNetworkConfig
+        }
       }
     }
   }


### PR DESCRIPTION
# 🦅 Pull Request Description

- Fixes #156 
- Uses `networkName` by default instead of the `network` property

Not sure what's the best way to test `configExtender()` though.

## 🚨 Test instructions

`npx buidler publish major --network rinkeby`

## ✔️ PR Todo

- [x] Include links to related issues/PRs
- [ ] Update unit tests for this change
- [x] Update the relevant documentation
- [x] Clear dependencies on other modules that have to be released before merging this


