### PR TITLE
Keychain: adds support for private keys as non-array

### DIFF
--- a/src/config/mnemonic.ts
+++ b/src/config/mnemonic.ts
@@ -1,7 +1,6 @@
 import { isHexString } from 'ethers/utils'
 import { homedir } from 'os'
 import path from 'path'
-import { isArray } from 'lodash'
 import { ConfigExtender, HttpNetworkConfig } from '@nomiclabs/buidler/types'
 import { aragenMnemonic } from '~/src/params'
 import { readJsonIfExists } from '~/src/utils/fsUtils'
@@ -47,7 +46,7 @@ export const configExtender: ConfigExtender = (finalConfig, userConfig) => {
       const { rpc, keys } = byNetworkMnemonic
       if (!finalNetwork.url && rpc) finalNetwork.url = rpc
       if (!finalNetwork.accounts && keys)
-        finalNetwork.accounts = isArray(keys)
+        finalNetwork.accounts = Array.isArray(keys)
           ? ensureHexEncoding(keys)
           : ensureHexEncoding([keys])
     }

--- a/src/config/mnemonic.ts
+++ b/src/config/mnemonic.ts
@@ -1,6 +1,7 @@
 import { isHexString } from 'ethers/utils'
 import { homedir } from 'os'
 import path from 'path'
+import { isArray } from 'lodash'
 import { ConfigExtender, HttpNetworkConfig } from '@nomiclabs/buidler/types'
 import { aragenMnemonic } from '~/src/params'
 import { readJsonIfExists } from '~/src/utils/fsUtils'
@@ -46,7 +47,9 @@ export const configExtender: ConfigExtender = (finalConfig, userConfig) => {
       const { rpc, keys } = byNetworkMnemonic
       if (!finalNetwork.url && rpc) finalNetwork.url = rpc
       if (!finalNetwork.accounts && keys)
-        finalNetwork.accounts = ensureHexEncoding(keys)
+        finalNetwork.accounts = isArray(keys)
+          ? ensureHexEncoding(keys)
+          : ensureHexEncoding([keys])
     }
     // Generic mnemonic
     if (genericMnemonic && !finalNetwork.accounts) {


### PR DESCRIPTION
# 🦅 Pull Request Description

- Adds support for a single key (non-array) from `mainnet_key.json` or `rinkeby_key.json` file.

## Rational

Multiple users have reported that the Buidler plugin didn't work after switching from aragonCLI. It turns out they had a key file that contained a single key, not in an array.
