### PR TITLE
Enable installation of apps on Rinkeby from the ExperimentalAppInstaller.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -240,12 +240,7 @@ export interface AclPermission {
  * App Installer types
  */
 
-export type NetworkType =
-  | 'homestead'
-  | 'rinkeby'
-  | 'ropsten'
-  | 'kovan'
-  | 'goerli'
+export type NetworkType = 'mainnet' | 'rinkeby' | 'ropsten' | 'kovan' | 'goerli'
 
 export interface AppOptions {
   version?: string


### PR DESCRIPTION
# 🦅 Pull Request Description

Replaced the `InfuraProvider` with a `JsonRpcProvider` in the `AppInstaller` so we can configure it to install apps that are installed to Rinkeby eg
```
await experimentalAppInstaller('finance', { network: 'rinkeby', skipInitialize: true })
```

## 🚨 Test instructions

Can test with the above example.

## ✔️ PR Todo

- [x] Include links to related issues/PRs
- [ ] Update unit tests for this change
- [x] Update the relevant documentation
- [x] Clear dependencies on other modules that have to be released before merging this
