### PR TITLE
Etherscan: update buidler-etherscan dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@aragon/abis": "^1.1.0",
     "@nomiclabs/buidler": "^1.3.0",
-    "@nomiclabs/buidler-etherscan": "^1.3.0",
+    "@nomiclabs/buidler-etherscan": "^2.0.0",
     "@nomiclabs/buidler-truffle5": "^1.3.0",
     "@nomiclabs/buidler-web3": "^1.3.0",
     "@types/chai": "^4.2.5",
@@ -88,7 +88,7 @@
   },
   "peerDependencies": {
     "@nomiclabs/buidler": "^1.3.0",
-    "@nomiclabs/buidler-etherscan": "^1.3.0",
+    "@nomiclabs/buidler-etherscan": "^2.0.0",
     "@nomiclabs/buidler-truffle5": "^1.3.0",
     "@nomiclabs/buidler-web3": "^1.3.0",
     "web3": "^1.2.0"


### PR DESCRIPTION
Updates to the latest `buidler-etherscan` version. AFAIK it doesn't have any API changes?